### PR TITLE
jose: Use claims type instead of map for NewSignedJWT

### DIFF
--- a/jose/jwt.go
+++ b/jose/jwt.go
@@ -63,13 +63,13 @@ func (j *JWT) Encode() string {
 	return strings.Join([]string{d, s}, ".")
 }
 
-func NewSignedJWT(claims map[string]interface{}, s Signer) (*JWT, error) {
+func NewSignedJWT(claims Claims, s Signer) (*JWT, error) {
 	header := JOSEHeader{
 		HeaderKeyAlgorithm: s.Alg(),
 		HeaderKeyID:        s.ID(),
 	}
 
-	jwt, err := NewJWT(header, Claims(claims))
+	jwt, err := NewJWT(header, claims)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use the claims type rather than passing a map to `NewSignedJWT(...)`