### PR TITLE
oauth2: don't fail if the token response does not expire

### DIFF
--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -250,9 +250,11 @@ func parseTokenResponse(resp *http.Response) (result TokenResponse, err error) {
 		if e == "" {
 			e = vals.Get("expires")
 		}
-		result.Expires, err = strconv.Atoi(e)
-		if err != nil {
-			return
+		if e != "" {
+			result.Expires, err = strconv.Atoi(e)
+			if err != nil {
+				return
+			}
 		}
 	} else {
 		b := make(map[string]interface{})


### PR DESCRIPTION
Some oauth2 implementations don't have an 'expires' or 'expires_in'
field, specifically GitHub. Don't fail if this happens.

Needed to use this package for coreos/dex#191