### PR TITLE
oidc: guard client provider config against race conditions

### DIFF
--- a/oidc/client_race_test.go
+++ b/oidc/client_race_test.go
@@ -1,0 +1,70 @@
+// This file contains tests which depend on the race detector being enabled.
+// +build race
+
+package oidc
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type testProvider struct {
+	baseURL string
+}
+
+func (p *testProvider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != discoveryConfigPath {
+		http.NotFound(w, r)
+		return
+	}
+
+	cfg := ProviderConfig{
+		Issuer: p.baseURL,
+	}
+	json.NewEncoder(w).Encode(&cfg)
+}
+
+// This test fails by triggering the race detector, not by calling t.Error or t.Fatal.
+func TestProviderSyncRace(t *testing.T) {
+
+	prov := &testProvider{}
+
+	s := httptest.NewServer(prov)
+	defer s.Close()
+	prov.baseURL = s.URL
+
+	prevValue := minimumProviderConfigSyncInterval
+	defer func() { minimumProviderConfigSyncInterval = prevValue }()
+
+	// Reduce the sync interval to increase the write frequencey.
+	minimumProviderConfigSyncInterval = 5 * time.Millisecond
+
+	cliCfg := ClientConfig{
+		HTTPClient: http.DefaultClient,
+		ProviderConfig: ProviderConfig{
+			Issuer:    s.URL,
+			ExpiresAt: time.Now().Add(time.Minute), // Must expire to trigger frequent syncs.
+		},
+	}
+	cli, err := NewClient(cliCfg)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// SyncProviderConfig beings a goroutine which writes to the client's provider config.
+	c := cli.SyncProviderConfig(s.URL)
+	defer func() {
+		// stop the background process
+		c <- struct{}{}
+	}()
+
+	for i := 0; i < 10; i++ {
+		time.Sleep(5 * time.Millisecond)
+		// Creating an OAuth client reads from the provider config.
+		cli.OAuthClient()
+	}
+}

--- a/oidc/client_test.go
+++ b/oidc/client_test.go
@@ -64,47 +64,42 @@ func TestHealthy(t *testing.T) {
 	now := time.Now().UTC()
 
 	tests := []struct {
-		c *Client
+		p ProviderConfig
 		h bool
 	}{
 		// all ok
 		{
-			c: &Client{
-				providerConfig: ProviderConfig{
-					Issuer:    "http://example.com",
-					ExpiresAt: now.Add(time.Hour),
-				},
+			p: ProviderConfig{
+				Issuer:    "http://example.com",
+				ExpiresAt: now.Add(time.Hour),
 			},
 			h: true,
 		},
 		// zero-value ProviderConfig.ExpiresAt
 		{
-			c: &Client{
-				providerConfig: ProviderConfig{
-					Issuer: "http://example.com",
-				},
+			p: ProviderConfig{
+				Issuer: "http://example.com",
 			},
 			h: true,
 		},
 		// expired ProviderConfig
 		{
-			c: &Client{
-				providerConfig: ProviderConfig{
-					Issuer:    "http://example.com",
-					ExpiresAt: now.Add(time.Hour * -1),
-				},
+			p: ProviderConfig{
+				Issuer:    "http://example.com",
+				ExpiresAt: now.Add(time.Hour * -1),
 			},
 			h: false,
 		},
 		// empty ProviderConfig
 		{
-			c: &Client{},
+			p: ProviderConfig{},
 			h: false,
 		},
 	}
 
 	for i, tt := range tests {
-		err := tt.c.Healthy()
+		c := &Client{providerConfig: newProviderConfigRepo(tt.p)}
+		err := c.Healthy()
 		want := tt.h
 		got := (err == nil)
 
@@ -347,12 +342,10 @@ func TestChooseAuthMethod(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		client := Client{
-			providerConfig: ProviderConfig{
-				TokenEndpointAuthMethodsSupported: tt.supported,
-			},
+		cfg := ProviderConfig{
+			TokenEndpointAuthMethodsSupported: tt.supported,
 		}
-		got, err := client.chooseAuthMethod()
+		got, err := chooseAuthMethod(cfg)
 		if tt.err {
 			if err == nil {
 				t.Errorf("case %d: expected non-nil err", i)

--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -25,6 +25,9 @@ const (
 	discoveryConfigPath = "/.well-known/openid-configuration"
 )
 
+// internally configurable for tests
+var minimumProviderConfigSyncInterval = MinimumProviderConfigSyncInterval
+
 type ProviderConfig struct {
 	Issuer                            string    `json:"issuer"`
 	AuthEndpoint                      string    `json:"authorization_endpoint"`
@@ -172,8 +175,8 @@ func nextSyncAfter(exp time.Time, clock clockwork.Clock) time.Duration {
 	t := exp.Sub(clock.Now()) / 2
 	if t > MaximumProviderConfigSyncInterval {
 		t = MaximumProviderConfigSyncInterval
-	} else if t < MinimumProviderConfigSyncInterval {
-		t = MinimumProviderConfigSyncInterval
+	} else if t < minimumProviderConfigSyncInterval {
+		t = minimumProviderConfigSyncInterval
 	}
 
 	return t

--- a/test
+++ b/test
@@ -12,6 +12,8 @@
 # Invoke ./cover for HTML output
 COVER=${COVER:-"-cover"}
 
+RACE=${RACE:-"-race"}
+
 source ./build
 
 TESTABLE="http jose key oauth2 oidc"
@@ -37,7 +39,7 @@ split=(${TEST// / })
 TEST=${split[@]/#/github.com/coreos/go-oidc/}
 
 echo "Running tests..."
-go test ${COVER} $@ ${TEST}
+go test $RACE ${COVER} $@ ${TEST}
 
 echo "Checking gofmt..."
 fmtRes=$(gofmt -l $FMT)


### PR DESCRIPTION
Add a RWMutex around a client's provider config to prevent race conditions when updating after syncing.

Test added which triggered the race condition before this change.

cc @yifan-gu, @bobbyrullo 