### PR TITLE
key: fix race condition in TestKeySyncerSync

### DIFF
--- a/key/repo.go
+++ b/key/repo.go
@@ -1,6 +1,9 @@
 package key
 
-import "errors"
+import (
+	"errors"
+	"sync"
+)
 
 var ErrorNoKeys = errors.New("no keys found")
 
@@ -22,6 +25,7 @@ func NewPrivateKeySetRepo() PrivateKeySetRepo {
 }
 
 type memPrivateKeySetRepo struct {
+	mu  sync.RWMutex
 	pks PrivateKeySet
 }
 
@@ -33,11 +37,17 @@ func (r *memPrivateKeySetRepo) Set(ks KeySet) error {
 		return errors.New("nil KeySet")
 	}
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	r.pks = *pks
 	return nil
 }
 
 func (r *memPrivateKeySetRepo) Get() (KeySet, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	if r.pks.keys == nil {
 		return nil, ErrorNoKeys
 	}

--- a/key/sync.go
+++ b/key/sync.go
@@ -29,7 +29,7 @@ func (s *KeySetSyncer) Run() chan struct{} {
 		var failing bool
 		var next time.Duration
 		for {
-			exp, err := sync(s.readable, s.writable, s.clock)
+			exp, err := syncKeySet(s.readable, s.writable, s.clock)
 			if err != nil || exp == 0 {
 				if !failing {
 					failing = true
@@ -62,12 +62,12 @@ func (s *KeySetSyncer) Run() chan struct{} {
 }
 
 func Sync(r ReadableKeySetRepo, w WritableKeySetRepo) (time.Duration, error) {
-	return sync(r, w, clockwork.NewRealClock())
+	return syncKeySet(r, w, clockwork.NewRealClock())
 }
 
-// sync copies the keyset from r to the KeySet at w and returns the duration in which the KeySet will expire.
+// syncKeySet copies the keyset from r to the KeySet at w and returns the duration in which the KeySet will expire.
 // If keyset has already expired, returns a zero duration.
-func sync(r ReadableKeySetRepo, w WritableKeySetRepo, clock clockwork.Clock) (exp time.Duration, err error) {
+func syncKeySet(r ReadableKeySetRepo, w WritableKeySetRepo, clock clockwork.Clock) (exp time.Duration, err error) {
 	var ks KeySet
 	ks, err = r.Get()
 	if err != nil {


### PR DESCRIPTION
Fix race condition in TestKeySyncerSync which was triggering the race detector for Go 1.5.X. Rename "sync" function so we can import the "sync" package and add RWMutexes to settable types.

Fixes #28