### PR TITLE
key: increase default RSA key size from 1024 to 2048 bits

### DIFF
--- a/key/key.go
+++ b/key/key.go
@@ -135,7 +135,7 @@ func (s *PrivateKeySet) Active() *PrivateKey {
 type GeneratePrivateKeyFunc func() (*PrivateKey, error)
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-	pk, err := rsa.GenerateKey(rand.Reader, 1024)
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Per @gtank's recommendations, increase the default RSA key size in
GeneratePrivateKey from 1024 to 2048 bits.

Closes #15