### PR TITLE
oidc: fix provider config field misname

### DIFF
--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -36,7 +36,7 @@ type ProviderConfig struct {
 	ResponseTypesSupported            []string  `json:"response_types_supported"`
 	GrantTypesSupported               []string  `json:"grant_types_supported"`
 	SubjectTypesSupported             []string  `json:"subject_types_supported"`
-	IDTokenAlgValuesSupported         []string  `json:"id_token_alg_values_supported"`
+	IDTokenAlgValuesSupported         []string  `json:"id_token_signing_alg_values_supported"`
 	TokenEndpointAuthMethodsSupported []string  `json:"token_endpoint_auth_methods_supported"`
 	ExpiresAt                         time.Time `json:"-"`
 }


### PR DESCRIPTION
"id_token_signing_alg_values_supported" is a required field in the OIDC provider metadata response and currently misnamed as "id_token_alg_values_supported". This commit corrects the field name.

Fixes #32