### PR TITLE
oidc: clean up provider and client metadata fields

### DIFF
--- a/oidc/client_test.go
+++ b/oidc/client_test.go
@@ -238,19 +238,19 @@ func TestClientMetadataValid(t *testing.T) {
 	tests := []ClientMetadata{
 		// one RedirectURL
 		ClientMetadata{
-			RedirectURIs: []*url.URL{&url.URL{Scheme: "http", Host: "example.com"}},
+			RedirectURIs: []url.URL{url.URL{Scheme: "http", Host: "example.com"}},
 		},
 
 		// one RedirectURL w/ nonempty path
 		ClientMetadata{
-			RedirectURIs: []*url.URL{&url.URL{Scheme: "http", Host: "example.com", Path: "/foo"}},
+			RedirectURIs: []url.URL{url.URL{Scheme: "http", Host: "example.com", Path: "/foo"}},
 		},
 
 		// two RedirectURIs
 		ClientMetadata{
-			RedirectURIs: []*url.URL{
-				&url.URL{Scheme: "http", Host: "foo.example.com"},
-				&url.URL{Scheme: "http", Host: "bar.example.com"},
+			RedirectURIs: []url.URL{
+				url.URL{Scheme: "http", Host: "foo.example.com"},
+				url.URL{Scheme: "http", Host: "bar.example.com"},
 			},
 		},
 	}
@@ -271,48 +271,48 @@ func TestClientMetadataInvalid(t *testing.T) {
 
 		// empty RedirectURIs slice
 		ClientMetadata{
-			RedirectURIs: []*url.URL{},
+			RedirectURIs: []url.URL{},
 		},
 
 		// empty url.URL
 		ClientMetadata{
-			RedirectURIs: []*url.URL{&url.URL{}},
+			RedirectURIs: []url.URL{url.URL{}},
 		},
 
 		// empty url.URL following OK item
 		ClientMetadata{
-			RedirectURIs: []*url.URL{&url.URL{Scheme: "http", Host: "example.com"}, &url.URL{}},
+			RedirectURIs: []url.URL{url.URL{Scheme: "http", Host: "example.com"}, url.URL{}},
 		},
 
 		// url.URL with empty Host
 		ClientMetadata{
-			RedirectURIs: []*url.URL{&url.URL{Scheme: "http", Host: ""}},
+			RedirectURIs: []url.URL{url.URL{Scheme: "http", Host: ""}},
 		},
 
 		// url.URL with empty Scheme
 		ClientMetadata{
-			RedirectURIs: []*url.URL{&url.URL{Scheme: "", Host: "example.com"}},
+			RedirectURIs: []url.URL{url.URL{Scheme: "", Host: "example.com"}},
 		},
 
 		// url.URL with non-HTTP(S) Scheme
 		ClientMetadata{
-			RedirectURIs: []*url.URL{&url.URL{Scheme: "tcp", Host: "127.0.0.1"}},
+			RedirectURIs: []url.URL{url.URL{Scheme: "tcp", Host: "127.0.0.1"}},
 		},
 
 		// EncryptionEnc without EncryptionAlg
 		ClientMetadata{
-			RedirectURIs: []*url.URL{&url.URL{Scheme: "http", Host: "example.com"}},
+			RedirectURIs: []url.URL{url.URL{Scheme: "http", Host: "example.com"}},
 			IDTokenResponseOptions: JWAOptions{
 				EncryptionEnc: "A128CBC-HS256",
 			},
 		},
 
-		// List of URIs with one nil element
+		// List of URIs with one empty element
 		ClientMetadata{
-			RedirectURIs: []*url.URL{&url.URL{Scheme: "http", Host: "example.com"}},
-			RequestURIs: []*url.URL{
-				&url.URL{Scheme: "http", Host: "example.com"},
-				nil,
+			RedirectURIs: []url.URL{url.URL{Scheme: "http", Host: "example.com"}},
+			RequestURIs: []url.URL{
+				url.URL{Scheme: "http", Host: "example.com"},
+				url.URL{},
 			},
 		},
 	}
@@ -388,7 +388,7 @@ func TestClientMetadataUnmarshal(t *testing.T) {
 		{
 			`{"redirect_uris":["https://example.com"]}`,
 			ClientMetadata{
-				RedirectURIs: []*url.URL{
+				RedirectURIs: []url.URL{
 					{Scheme: "https", Host: "example.com"},
 				},
 			},
@@ -409,10 +409,10 @@ func TestClientMetadataUnmarshal(t *testing.T) {
 		{
 			`{"redirect_uris":["https://example.com"],"contacts":["Ms. Foo <foo@example.com>"]}`,
 			ClientMetadata{
-				RedirectURIs: []*url.URL{
+				RedirectURIs: []url.URL{
 					{Scheme: "https", Host: "example.com"},
 				},
-				Contacts: []*mail.Address{
+				Contacts: []mail.Address{
 					{Name: "Ms. Foo", Address: "foo@example.com"},
 				},
 			},
@@ -440,14 +440,14 @@ func TestClientMetadataUnmarshal(t *testing.T) {
 				]
 			}`,
 			ClientMetadata{
-				RedirectURIs: []*url.URL{
+				RedirectURIs: []url.URL{
 					{Scheme: "https", Host: "example.com"},
 				},
 				UserInfoResponseOptions: JWAOptions{
 					EncryptionAlg: "RSA1_5",
 					EncryptionEnc: "A128CBC-HS256",
 				},
-				Contacts: []*mail.Address{
+				Contacts: []mail.Address{
 					{Name: "jane doe", Address: "jane.doe@example.com"},
 					{Name: "john doe", Address: "john.doe@example.com"},
 				},
@@ -491,7 +491,7 @@ func TestClientMetadataMarshal(t *testing.T) {
 	}{
 		{
 			ClientMetadata{
-				RedirectURIs: []*url.URL{
+				RedirectURIs: []url.URL{
 					{Scheme: "https", Host: "example.com", Path: "/callback"},
 				},
 			},
@@ -499,7 +499,7 @@ func TestClientMetadataMarshal(t *testing.T) {
 		},
 		{
 			ClientMetadata{
-				RedirectURIs: []*url.URL{
+				RedirectURIs: []url.URL{
 					{Scheme: "https", Host: "example.com", Path: "/callback"},
 				},
 				RequestObjectOptions: JWAOptions{
@@ -526,7 +526,7 @@ func TestClientMetadataMarshal(t *testing.T) {
 func TestClientMetadataMarshalRoundTrip(t *testing.T) {
 	tests := []ClientMetadata{
 		{
-			RedirectURIs: []*url.URL{
+			RedirectURIs: []url.URL{
 				{Scheme: "https", Host: "example.com", Path: "/callback"},
 			},
 			LogoURI: &url.URL{Scheme: "https", Host: "example.com", Path: "/logo"},
@@ -579,7 +579,7 @@ func TestClientRegistrationResponseUnmarshal(t *testing.T) {
 				ClientSecret:          "bar",
 				ClientSecretExpiresAt: time.Unix(1577858400, 0),
 				ClientMetadata: ClientMetadata{
-					RedirectURIs: []*url.URL{
+					RedirectURIs: []url.URL{
 						{Scheme: "https", Host: "client.example.org", Path: "/callback"},
 						{Scheme: "https", Host: "client.example.org", Path: "/callback2"},
 					},
@@ -602,7 +602,7 @@ func TestClientRegistrationResponseUnmarshal(t *testing.T) {
 			ClientRegistrationResponse{
 				ClientID: "foo",
 				ClientMetadata: ClientMetadata{
-					RedirectURIs: []*url.URL{
+					RedirectURIs: []url.URL{
 						{Scheme: "https", Host: "client.example.org", Path: "/callback"},
 						{Scheme: "https", Host: "client.example.org", Path: "/callback2"},
 					},

--- a/oidc/provider_test.go
+++ b/oidc/provider_test.go
@@ -128,21 +128,15 @@ func TestProviderConfigUnmarshal(t *testing.T) {
 				SubjectTypesSupported: []string{
 					SubjectTypePublic, SubjectTypePairwise,
 				},
-				UserInfoOptions: JWAValuesSupported{
-					SigningAlgs:    []string{jose.AlgRS256, jose.AlgES256, jose.AlgHS256},
-					EncryptionAlgs: []string{"RSA1_5", "A128KW"},
-					EncryptionEncs: []string{"A128CBC-HS256", "A128GCM"},
-				},
-				IDTokenOptions: JWAValuesSupported{
-					SigningAlgs:    []string{jose.AlgRS256, jose.AlgES256, jose.AlgHS256},
-					EncryptionAlgs: []string{"RSA1_5", "A128KW"},
-					EncryptionEncs: []string{"A128CBC-HS256", "A128GCM"},
-				},
-				RequestObjectOptions: JWAValuesSupported{
-					SigningAlgs: []string{jose.AlgNone, jose.AlgRS256, jose.AlgES256},
-				},
-				DisplayValuesSupported: []string{"page", "popup"},
-				ClaimTypesSupported:    []string{"normal", "distributed"},
+				UserInfoSigningAlgValues:    []string{jose.AlgRS256, jose.AlgES256, jose.AlgHS256},
+				UserInfoEncryptionAlgValues: []string{"RSA1_5", "A128KW"},
+				UserInfoEncryptionEncValues: []string{"A128CBC-HS256", "A128GCM"},
+				IDTokenSigningAlgValues:     []string{jose.AlgRS256, jose.AlgES256, jose.AlgHS256},
+				IDTokenEncryptionAlgValues:  []string{"RSA1_5", "A128KW"},
+				IDTokenEncryptionEncValues:  []string{"A128CBC-HS256", "A128GCM"},
+				ReqObjSigningAlgValues:      []string{jose.AlgNone, jose.AlgRS256, jose.AlgES256},
+				DisplayValuesSupported:      []string{"page", "popup"},
+				ClaimTypesSupported:         []string{"normal", "distributed"},
 				ClaimsSupported: []string{
 					"sub", "iss", "auth_time", "acr", "name", "given_name",
 					"family_name", "nickname", "profile", "picture", "website",
@@ -185,9 +179,7 @@ func TestProviderConfigUnmarshal(t *testing.T) {
 				SubjectTypesSupported: []string{
 					SubjectTypePublic, SubjectTypePairwise,
 				},
-				IDTokenOptions: JWAValuesSupported{
-					SigningAlgs: []string{jose.AlgRS256, jose.AlgES256, jose.AlgHS256},
-				},
+				IDTokenSigningAlgValues: []string{jose.AlgRS256, jose.AlgES256, jose.AlgHS256},
 			},
 			wantErr: false,
 		},
@@ -247,11 +239,9 @@ func TestProviderConfigMarshal(t *testing.T) {
 				KeysEndpoint: &url.URL{
 					Scheme: "https", Host: "auth.example.com", Path: "/jwk",
 				},
-				ResponseTypesSupported: []string{oauth2.ResponseTypeCode},
-				SubjectTypesSupported:  []string{SubjectTypePublic},
-				IDTokenOptions: JWAValuesSupported{
-					SigningAlgs: []string{jose.AlgRS256},
-				},
+				ResponseTypesSupported:  []string{oauth2.ResponseTypeCode},
+				SubjectTypesSupported:   []string{SubjectTypePublic},
+				IDTokenSigningAlgValues: []string{jose.AlgRS256},
 			},
 			// spacing must match json.MarshalIndent(cfg, "", "\t")
 			want: `{
@@ -289,15 +279,13 @@ func TestProviderConfigMarshal(t *testing.T) {
 				RegistrationEndpoint: &url.URL{
 					Scheme: "https", Host: "auth.example.com", Path: "/register",
 				},
-				ScopesSupported:        DefaultScope,
-				ResponseTypesSupported: []string{oauth2.ResponseTypeCode},
-				ResponseModesSupported: DefaultResponseModesSupported,
-				GrantTypesSupported:    []string{oauth2.GrantTypeAuthCode},
-				SubjectTypesSupported:  []string{SubjectTypePublic},
-				IDTokenOptions: JWAValuesSupported{
-					SigningAlgs: []string{jose.AlgRS256},
-				},
-				ServiceDocs: &url.URL{Scheme: "https", Host: "example.com", Path: "/docs"},
+				ScopesSupported:         DefaultScope,
+				ResponseTypesSupported:  []string{oauth2.ResponseTypeCode},
+				ResponseModesSupported:  DefaultResponseModesSupported,
+				GrantTypesSupported:     []string{oauth2.GrantTypeAuthCode},
+				SubjectTypesSupported:   []string{SubjectTypePublic},
+				IDTokenSigningAlgValues: []string{jose.AlgRS256},
+				ServiceDocs:             &url.URL{Scheme: "https", Host: "example.com", Path: "/docs"},
 			},
 			// spacing must match json.MarshalIndent(cfg, "", "\t")
 			want: `{
@@ -366,7 +354,7 @@ func TestProviderConfigSupports(t *testing.T) {
 		{
 			provider: ProviderConfig{},
 			client: ClientMetadata{
-				RedirectURIs: []*url.URL{
+				RedirectURIs: []url.URL{
 					{Scheme: "https", Host: "example.com", Path: "/callback"},
 				},
 			},
@@ -377,7 +365,7 @@ func TestProviderConfigSupports(t *testing.T) {
 			// invalid provider config
 			provider: ProviderConfig{},
 			client: ClientMetadata{
-				RedirectURIs: []*url.URL{
+				RedirectURIs: []url.URL{
 					{Scheme: "https", Host: "example.com", Path: "/callback"},
 				},
 			},
@@ -430,7 +418,7 @@ func fillRequiredProviderFields(cfg ProviderConfig) ProviderConfig {
 	cfg.KeysEndpoint = urlPath("/jwk")
 	cfg.ResponseTypesSupported = []string{oauth2.ResponseTypeCode}
 	cfg.SubjectTypesSupported = []string{SubjectTypePublic}
-	cfg.IDTokenOptions.SigningAlgs = []string{jose.AlgRS256}
+	cfg.IDTokenSigningAlgValues = []string{jose.AlgRS256}
 	return cfg
 }
 


### PR DESCRIPTION
From out of bounds conversation with @bobbyrullo.

1. Make ClientMetadata slice fields non-nillable e7e315eb55ea0318af5de7f3f2c83f1026fe7ca2
2. Remove JWAValuesSupported struct 193a278be42b4ecc4f05be0c06226e4c9fd884f1