### PR TITLE
provider: Use path.Join() to construct the URL.

### DIFF
--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"sync"
 	"time"
 
@@ -618,7 +619,7 @@ func NewHTTPProviderConfigGetter(hc phttp.Client, issuerURL string) *httpProvide
 }
 
 func (r *httpProviderConfigGetter) Get() (cfg ProviderConfig, err error) {
-	req, err := http.NewRequest("GET", r.issuerURL+discoveryConfigPath, nil)
+	req, err := http.NewRequest("GET", path.Join(r.issuerURL, discoveryConfigPath), nil)
 	if err != nil {
 		return
 	}

--- a/oidc/provider_test.go
+++ b/oidc/provider_test.go
@@ -546,6 +546,15 @@ func TestHTTPProviderConfigGetter(t *testing.T) {
 			},
 			ok: true,
 		},
+		// issuer URL has a tailing slash.
+		{
+			dsc: "https://foo.com/",
+			age: -1,
+			cfg: ProviderConfig{
+				Issuer: &url.URL{Scheme: "https", Host: "foo.com", Path: "/"},
+			},
+			ok: true,
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Should fix https://github.com/kubernetes/kubernetes/issues/20476

cc @bobbyrullo @ericchiang 