### PR TITLE
add revocation_endpoint in provider config

### DIFF
--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -68,6 +68,7 @@ type ProviderConfig struct {
 	UserInfoEndpoint     *url.URL
 	KeysEndpoint         *url.URL // Required
 	RegistrationEndpoint *url.URL
+	RevocationEndpoint   *url.URL
 
 	// Servers MAY choose not to advertise some supported scope values even when this
 	// parameter is used, although those defined in OpenID Core SHOULD be listed, if supported.
@@ -169,6 +170,7 @@ type encodableProviderConfig struct {
 	UserInfoEndpoint     string `json:"userinfo_endpoint,omitempty"`
 	KeysEndpoint         string `json:"jwks_uri"`
 	RegistrationEndpoint string `json:"registration_endpoint,omitempty"`
+	RevocationEndpoint   string `json:"revocation_endpoint,omitempty"`
 
 	// Use 'omitempty' for all slices as per OIDC spec:
 	// "Claims that return multiple values are represented as JSON arrays.
@@ -218,6 +220,7 @@ func (cfg ProviderConfig) toEncodableStruct() encodableProviderConfig {
 		UserInfoEndpoint:                           uriToString(cfg.UserInfoEndpoint),
 		KeysEndpoint:                               uriToString(cfg.KeysEndpoint),
 		RegistrationEndpoint:                       uriToString(cfg.RegistrationEndpoint),
+		RevocationEndpoint:                         uriToString(cfg.RevocationEndpoint),
 		ScopesSupported:                            cfg.ScopesSupported,
 		ResponseTypesSupported:                     cfg.ResponseTypesSupported,
 		ResponseModesSupported:                     cfg.ResponseModesSupported,
@@ -259,6 +262,7 @@ func (e encodableProviderConfig) toStruct() (ProviderConfig, error) {
 		UserInfoEndpoint:                           p.parseURI(e.UserInfoEndpoint, "userinfo_endpoint"),
 		KeysEndpoint:                               p.parseURI(e.KeysEndpoint, "jwks_uri"),
 		RegistrationEndpoint:                       p.parseURI(e.RegistrationEndpoint, "registration_endpoint"),
+		RevocationEndpoint:                         p.parseURI(e.RevocationEndpoint, "revocation_endpoint"),
 		ScopesSupported:                            e.ScopesSupported,
 		ResponseTypesSupported:                     e.ResponseTypesSupported,
 		ResponseModesSupported:                     e.ResponseModesSupported,
@@ -363,6 +367,7 @@ func (p ProviderConfig) Valid() error {
 		{p.UserInfoEndpoint, "userinfo_endpoint", false},
 		{p.KeysEndpoint, "jwks_uri", true},
 		{p.RegistrationEndpoint, "registration_endpoint", false},
+		{p.RevocationEndpoint, "revocation_endpoint", false},
 		{p.ServiceDocs, "service_documentation", false},
 		{p.Policy, "op_policy_uri", false},
 		{p.TermsOfService, "op_tos_uri", false},

--- a/oidc/provider_test.go
+++ b/oidc/provider_test.go
@@ -72,6 +72,7 @@ func TestProviderConfigUnmarshal(t *testing.T) {
 				"userinfo_endpoint": "https://server.example.com/connect/userinfo",
 				"jwks_uri": "https://server.example.com/jwks.json",
 				"registration_endpoint": "https://server.example.com/connect/register",
+				"revocation_endpoint": "https://server.example.com/connect/revoke",
 				"scopes_supported": [
 					"openid", "profile", "email", "address", "phone", "offline_access"
 				],
@@ -115,6 +116,7 @@ func TestProviderConfigUnmarshal(t *testing.T) {
 				UserInfoEndpoint:     uri("/connect/userinfo"),
 				KeysEndpoint:         uri("/jwks.json"),
 				RegistrationEndpoint: uri("/connect/register"),
+				RevocationEndpoint:   uri("/connect/revoke"),
 				ScopesSupported: []string{
 					"openid", "profile", "email", "address", "phone", "offline_access",
 				},
@@ -279,6 +281,9 @@ func TestProviderConfigMarshal(t *testing.T) {
 				RegistrationEndpoint: &url.URL{
 					Scheme: "https", Host: "auth.example.com", Path: "/register",
 				},
+				RevocationEndpoint: &url.URL{
+					Scheme: "https", Host: "auth.example.com", Path: "/revoke",
+				},
 				ScopesSupported:         DefaultScope,
 				ResponseTypesSupported:  []string{oauth2.ResponseTypeCode},
 				ResponseModesSupported:  DefaultResponseModesSupported,
@@ -295,6 +300,7 @@ func TestProviderConfigMarshal(t *testing.T) {
 	"userinfo_endpoint": "https://auth.example.com/userinfo",
 	"jwks_uri": "https://auth.example.com/jwk",
 	"registration_endpoint": "https://auth.example.com/register",
+	"revocation_endpoint": "https://auth.example.com/revoke",
 	"scopes_supported": [
 		"openid",
 		"email",


### PR DESCRIPTION
I know this is not define in spec, but usually there is a revocation endpoint.
https://login.salesforce.com/.well-known/openid-configuration
https://accounts.google.com/.well-known/openid-configuration

Fixes #48
