### PR TITLE
oidc: fix decoding panic case

### DIFF
--- a/oidc/client.go
+++ b/oidc/client.go
@@ -311,7 +311,9 @@ func (p *stickyErrParser) parseURIs(s []string, field string) []url.URL {
 			p.firstErr = fmt.Errorf("invalid URI in field %s", field)
 			return nil
 		}
-		uris[i] = *(p.parseURI(val, field))
+		if u := p.parseURI(val, field); u != nil {
+			uris[i] = *u
+		}
 	}
 	return uris
 }


### PR DESCRIPTION
Error found when working on dex. If parsing a URI fails, the parser
will attempt to get the concrete value of a nil pointer.