### PR TITLE
http: remove HandlerClient and RequestRecorder

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -1,51 +1,7 @@
 package http
 
-import (
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-)
+import "net/http"
 
 type Client interface {
 	Do(*http.Request) (*http.Response, error)
-}
-
-type HandlerClient struct {
-	Handler http.Handler
-}
-
-func (hc *HandlerClient) Do(r *http.Request) (*http.Response, error) {
-	w := httptest.NewRecorder()
-	hc.Handler.ServeHTTP(w, r)
-
-	resp := http.Response{
-		StatusCode: w.Code,
-		Header:     w.Header(),
-		Body:       ioutil.NopCloser(w.Body),
-	}
-
-	return &resp, nil
-}
-
-type RequestRecorder struct {
-	Response *http.Response
-	Error    error
-
-	Request *http.Request
-}
-
-func (rr *RequestRecorder) Do(req *http.Request) (*http.Response, error) {
-	rr.Request = req
-
-	if rr.Response == nil && rr.Error == nil {
-		panic("RequestRecorder Response and Error cannot both be nil")
-	} else if rr.Response != nil && rr.Error != nil {
-		panic("RequestRecorder Response and Error cannot both be non-nil")
-	}
-
-	return rr.Response, rr.Error
-}
-
-func (rr *RequestRecorder) RoundTrip(req *http.Request) (*http.Response, error) {
-	return rr.Do(req)
 }

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -158,8 +158,18 @@ func TestParseAuthCodeRequest(t *testing.T) {
 	}
 }
 
+type fakeBadClient struct {
+	Request *http.Request
+	err     error
+}
+
+func (f *fakeBadClient) Do(r *http.Request) (*http.Response, error) {
+	f.Request = r
+	return nil, f.err
+}
+
 func TestClientCredsToken(t *testing.T) {
-	hc := &phttp.RequestRecorder{Error: errors.New("error")}
+	hc := &fakeBadClient{nil, errors.New("error")}
 	cfg := Config{
 		Credentials: ClientCredentials{ID: "cid", Secret: "csecret"},
 		Scope:       []string{"foo-scope", "bar-scope"},
@@ -238,7 +248,6 @@ func TestNewAuthenticatedRequest(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		hc := &phttp.HandlerClient{}
 		cfg := Config{
 			Credentials: ClientCredentials{ID: "cid", Secret: "csecret"},
 			Scope:       []string{"foo-scope", "bar-scope"},
@@ -247,7 +256,7 @@ func TestNewAuthenticatedRequest(t *testing.T) {
 			RedirectURL: "http://example.com/redirect",
 			AuthMethod:  tt.authMethod,
 		}
-		c, err := NewClient(hc, cfg)
+		c, err := NewClient(nil, cfg)
 		req, err := c.newAuthenticatedRequest(tt.url, tt.values)
 		if err != nil {
 			t.Errorf("case %d: unexpected error: %v", i, err)

--- a/oidc/transport_test.go
+++ b/oidc/transport_test.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"testing"
 
-	phttp "github.com/coreos/go-oidc/http"
 	"github.com/coreos/go-oidc/jose"
 )
 
@@ -122,8 +121,18 @@ func TestAuthenticatedTransportJWTCaching(t *testing.T) {
 	}
 }
 
+type fakeRoundTripper struct {
+	Request *http.Request
+	resp    *http.Response
+}
+
+func (r *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.Request = req
+	return r.resp, nil
+}
+
 func TestAuthenticatedTransportRoundTrip(t *testing.T) {
-	rr := &phttp.RequestRecorder{Response: &http.Response{StatusCode: http.StatusOK}}
+	rr := &fakeRoundTripper{nil, &http.Response{StatusCode: http.StatusOK}}
 	at := &AuthenticatedTransport{
 		TokenRefresher: &staticTokenRefresher{
 			verify: func(jose.JWT) error { return nil },
@@ -150,7 +159,7 @@ func TestAuthenticatedTransportRoundTrip(t *testing.T) {
 }
 
 func TestAuthenticatedTransportRoundTripRefreshFail(t *testing.T) {
-	rr := &phttp.RequestRecorder{Response: &http.Response{StatusCode: http.StatusOK}}
+	rr := &fakeRoundTripper{nil, &http.Response{StatusCode: http.StatusOK}}
 	at := &AuthenticatedTransport{
 		TokenRefresher: &staticTokenRefresher{
 			verify:  func(jose.JWT) error { return errors.New("fail!") },


### PR DESCRIPTION
Users should just use net/http/httptest instead.

Closes #57