### PR TITLE
client config keyset default expiration

### DIFF
--- a/oidc/key.go
+++ b/oidc/key.go
@@ -11,13 +11,14 @@ import (
 	"github.com/coreos/go-oidc/key"
 )
 
-func NewRemotePublicKeyRepo(hc phttp.Client, ep string) *remotePublicKeyRepo {
-	return &remotePublicKeyRepo{hc: hc, ep: ep}
+func NewRemotePublicKeyRepo(hc phttp.Client, ep string, exp time.Duration) *remotePublicKeyRepo {
+	return &remotePublicKeyRepo{hc: hc, ep: ep, exp: exp}
 }
 
 type remotePublicKeyRepo struct {
-	hc phttp.Client
-	ep string
+	hc  phttp.Client
+	ep  string
+	exp time.Duration
 }
 
 func (r *remotePublicKeyRepo) Get() (key.KeySet, error) {
@@ -47,11 +48,15 @@ func (r *remotePublicKeyRepo) Get() (key.KeySet, error) {
 	if err != nil {
 		return nil, err
 	}
+	var exp time.Time
 	if !ok {
-		return nil, errors.New("HTTP cache headers not set")
+		if r.exp < 0 {
+			return nil, errors.New("HTTP cache headers not set")
+		}
+		exp = time.Now().UTC().Add(r.exp)
+	} else {
+		exp = time.Now().UTC().Add(ttl)
 	}
-
-	exp := time.Now().UTC().Add(ttl)
 	ks := key.NewPublicKeySet(d.Keys, exp)
 	return ks, nil
 }


### PR DESCRIPTION
- adding the ability to have a default timeout for the keyset, as some idp do not have the appropriate headers