### PR TITLE
jose/oidc fixes for non-comformity

### DIFF
--- a/jose/sig.go
+++ b/jose/sig.go
@@ -2,7 +2,6 @@ package jose
 
 import (
 	"fmt"
-	"strings"
 )
 
 type Verifier interface {
@@ -17,7 +16,7 @@ type Signer interface {
 }
 
 func NewVerifier(jwk JWK) (Verifier, error) {
-	if strings.ToUpper(jwk.Type) != "RSA" {
+	if jwk.Type != "RSA" {
 		return nil, fmt.Errorf("unsupported key type %q", jwk.Type)
 	}
 

--- a/jose/sig_hmac.go
+++ b/jose/sig_hmac.go
@@ -7,7 +7,6 @@ import (
 	_ "crypto/sha256"
 	"errors"
 	"fmt"
-	"strings"
 )
 
 type VerifierHMAC struct {
@@ -21,7 +20,7 @@ type SignerHMAC struct {
 }
 
 func NewVerifierHMAC(jwk JWK) (*VerifierHMAC, error) {
-	if strings.ToUpper(jwk.Alg) != "HS256" {
+	if jwk.Alg != "" && jwk.Alg != "HS256" {
 		return nil, fmt.Errorf("unsupported key algorithm %q", jwk.Alg)
 	}
 

--- a/jose/sig_rsa.go
+++ b/jose/sig_rsa.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
-	"strings"
 )
 
 type VerifierRSA struct {
@@ -20,7 +19,7 @@ type SignerRSA struct {
 }
 
 func NewVerifierRSA(jwk JWK) (*VerifierRSA, error) {
-	if strings.ToUpper(jwk.Alg) != "RS256" {
+	if jwk.Alg != "" && jwk.Alg != "RS256" {
 		return nil, fmt.Errorf("unsupported key algorithm %q", jwk.Alg)
 	}
 


### PR DESCRIPTION
**JOSE**
JWK's "kty" parameter is case-sensitive:
https://tools.ietf.org/html/rfc7517#section-4.1

The "alg" parameter is case-sensitive and optional:
https://tools.ietf.org/html/rfc7517#section-4.4

Given that it is optional, I think it's safe to assume that there should be a default (the specification has a "recommended" algorithm for each "kty"). This appears to be the behaviour with other clients and servers.

**OIDC**
The specification only states that jwks_uri SHOULD have a Cache-Control header:
http://openid.net/specs/openid-connect-core-1_0.html#rfc.section.10.2.1
