### PR TITLE
Fixed PublicKey JSON Marshaling

### DIFF
--- a/key/key.go
+++ b/key/key.go
@@ -20,7 +20,7 @@ type PublicKey struct {
 }
 
 func (k *PublicKey) MarshalJSON() ([]byte, error) {
-	return json.Marshal(k.jwk)
+	return json.Marshal(&k.jwk)
 }
 
 func (k *PublicKey) UnmarshalJSON(data []byte) error {

--- a/key/key_test.go
+++ b/key/key_test.go
@@ -66,3 +66,24 @@ func TestPublicKeySetKey(t *testing.T) {
 		t.Errorf("Expected nil response from PublicKeySet.Key, got %#v", got)
 	}
 }
+
+func TestPublicKeyMarshalJSON(t *testing.T) {
+	k := jose.JWK{
+		ID:       "foo",
+		Type:     "RSA",
+		Alg:      "RS256",
+		Use:      "sig",
+		Modulus:  big.NewInt(int64(17)),
+		Exponent: 65537,
+	}
+	want := `{"kid":"foo","kty":"RSA","alg":"RS256","use":"sig","e":"AQAB","n":"EQ=="}`
+	pubKey := NewPublicKey(k)
+	gotBytes, err := pubKey.MarshalJSON()
+	if err != nil {
+		t.Fatalf("failed to marshal public key: %v", err)
+	}
+	got := string(gotBytes)
+	if got != want {
+		t.Errorf("got != want:\n%s\n%s", got, want)
+	}
+}


### PR DESCRIPTION
Because the `MarshalJSON()` method implemented by `jose/JWK` has a pointer receiver, we must pass a pointer to it. Otherwise, the method is never called when a `key/PublicKey` instance is marshaled, the Go default MarshalJSON function is used on `jose/JWK`. Consequently, the JSON data for a PublicKey is invalid (i.e. modulus and exponent are not properly encoded) and it is impossible to unmarshal it back to a valid PublicKey.