### PR TITLE
oauth2: return embedded http client

### DIFF
--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -140,6 +140,11 @@ func NewClient(hc phttp.Client, cfg Config) (c *Client, err error) {
 	return
 }
 
+// Return the embedded HTTP client
+func (c *Client) HttpClient() phttp.Client {
+	return c.hc
+}
+
 // Generate the url for initial redirect to oauth provider.
 func (c *Client) AuthCodeURL(state, accessType, prompt string) string {
 	v := c.commonURLValues()


### PR DESCRIPTION
This is a prerequisite to a fix for https://github.com/coreos/dex/issues/395.

Happy to add tests if you agree this is potentially mergeable.

(Things will look different with #64, but I'd be happy to help transitioning, too.)