### PR TITLE
*: decode iat and exp as int64

### DIFF
--- a/jose/claims_test.go
+++ b/jose/claims_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/jonboulle/clockwork"
 )
 
 func TestString(t *testing.T) {
@@ -323,6 +325,42 @@ func TestStringArray(t *testing.T) {
 
 		if !reflect.DeepEqual(tt.val, val) {
 			t.Errorf("case %d: want val=%v, got val=%v", i, tt.val, val)
+		}
+	}
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	tests := []struct {
+		claims Claims
+	}{
+		{
+			claims: Claims{
+				"iat": clock.Now().Unix(),
+			},
+		},
+		{
+			claims: Claims{
+				"iat": clock.Now().Unix(),
+				"exp": clock.Now().Add(time.Hour).Unix(),
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		payload, err := marshalClaims(tt.claims)
+		if err != nil {
+			t.Errorf("case %d: failed to marshal claims: %v", i, err)
+			return
+		}
+		got, err := decodeClaims(payload)
+		if err != nil {
+			t.Errorf("case %d: failed to decode claims: %v", i, err)
+			return
+		}
+		if !reflect.DeepEqual(tt.claims, got) {
+			t.Errorf("case %d: want val=%v, got val=%v", i, tt.claims, got)
 		}
 	}
 }

--- a/jose/jwt_test.go
+++ b/jose/jwt_test.go
@@ -22,7 +22,7 @@ func TestParseJWT(t *testing.T) {
 			Claims{
 				"iss": "joe",
 				// NOTE: test numbers must be floats for equality checks to work since values are converted form interface{} to float64 by default.
-				"exp": 1300819380.0,
+				"exp": int64(1300819380),
 				"http://example.com/is_root": true,
 			},
 		},

--- a/oidc/verification.go
+++ b/oidc/verification.go
@@ -69,8 +69,15 @@ func VerifyClaims(jwt jose.JWT, issuer, clientID string) error {
 	// iat REQUIRED. Time at which the JWT was issued.
 	// Its value is a JSON number representing the number of seconds from 1970-01-01T0:0:0Z
 	// as measured in UTC until the date/time.
-	if _, exists := claims["iat"].(float64); !exists {
+	if iat, ok := claims["iat"]; !ok {
 		return errors.New("missing claim: 'iat'")
+	} else {
+		// Ensure the claim is either a float or an int.
+		switch iat.(type) {
+		case float64, int64, int32, int:
+		default:
+			return errors.New("missing claim: 'iat'")
+		}
 	}
 
 	// aud REQUIRED. Audience(s) that this ID Token is intended for.


### PR DESCRIPTION
Since #56 this package encodes the 'iat' and 'exp' claims as int64
instead of float64. However it still decodes them as a float64.
This causes comparisions to fail in tests that use some version of
reflect.DeepEqual. See coreos/dex#418.

To avoid this, attempt to decode the 'iat' and 'exp' explicitly as
int64 if possible.

cc @sym3tri @bobbyrullo 