### PR TITLE
removing the debug log

### DIFF
--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -537,7 +537,7 @@ func (s *ProviderConfigSyncer) sync() (time.Duration, error) {
 		s.initialSyncDone = true
 	}
 
-	log.Infof("Updating provider config: config=%#v", cfg)
+	log.Debugf("Updating provider config: config=%#v", cfg)
 
 	return nextSyncAfter(cfg.ExpiresAt, s.clock), nil
 }


### PR DESCRIPTION
- changing from info to debug level on the provider config as it more debug and required information. On similar note, it would be nice to allow the consumer to set the io.Writer on the logs?