### PR TITLE
oauth2: add support for Azure AD

### DIFF
--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -332,16 +332,16 @@ func parseTokenResponse(resp *http.Response) (result TokenResponse, err error) {
 		result.Scope = vals.Get("scope")
 	} else {
 		var r struct {
-			AccessToken  string `json:"access_token"`
-			TokenType    string `json:"token_type"`
-			IDToken      string `json:"id_token"`
-			RefreshToken string `json:"refresh_token"`
-			Scope        string `json:"scope"`
-			State        string `json:"state"`
-			ExpiresIn    int    `json:"expires_in"`
-			Expires      int    `json:"expires"`
-			Error        string `json:"error"`
-			Desc         string `json:"error_description"`
+			AccessToken  string      `json:"access_token"`
+			TokenType    string      `json:"token_type"`
+			IDToken      string      `json:"id_token"`
+			RefreshToken string      `json:"refresh_token"`
+			Scope        string      `json:"scope"`
+			State        string      `json:"state"`
+			ExpiresIn    json.Number `json:"expires_in"` // Azure AD returns string
+			Expires      int         `json:"expires"`
+			Error        string      `json:"error"`
+			Desc         string      `json:"error_description"`
 		}
 		if err = json.Unmarshal(body, &r); err != nil {
 			return
@@ -355,10 +355,10 @@ func parseTokenResponse(resp *http.Response) (result TokenResponse, err error) {
 		result.IDToken = r.IDToken
 		result.RefreshToken = r.RefreshToken
 		result.Scope = r.Scope
-		if r.ExpiresIn == 0 {
+		if expiresIn, err := r.ExpiresIn.Int64(); err != nil {
 			result.Expires = r.Expires
 		} else {
-			result.Expires = r.ExpiresIn
+			result.Expires = int(expiresIn)
 		}
 	}
 	return

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -439,6 +439,20 @@ func TestParseTokenResponse(t *testing.T) {
 			},
 		},
 		{
+			// Azure AD returns "expires_in" value as string
+			resp: response{
+				body:        `{"access_token":"foo","id_token":"bar","expires_in":"300","token_type":"bearer","refresh_token":"spam"}`,
+				contentType: "application/json; charset=utf-8",
+			},
+			wantResp: TokenResponse{
+				AccessToken:  "foo",
+				IDToken:      "bar",
+				Expires:      300,
+				TokenType:    "bearer",
+				RefreshToken: "spam",
+			},
+		},
+		{
 			resp: response{
 				body:        `{"access_token":"foo","id_token":"bar","expires":200,"token_type":"bearer","refresh_token":"spam"}`,
 				contentType: "application/json; charset=utf-8",


### PR DESCRIPTION
This change adds support for Azure AD token response on Code Flow.

Though RFC6749 section 5.1 states Numerical values are included as
JSON numbers, Azure AD returns "expires_in" value as string.

see Azure AD JSON example
https://msdn.microsoft.com/en-us//library/azure/dn645542.aspx