### PR TITLE
key: use shorter key ids

### DIFF
--- a/key/key.go
+++ b/key/key.go
@@ -3,9 +3,9 @@ package key
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
-	"math/big"
+	"io"
 	"time"
 
 	"github.com/coreos/go-oidc/jose"
@@ -139,15 +139,15 @@ func GeneratePrivateKey() (*PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
+	keyID := make([]byte, 20)
+	if _, err := io.ReadFull(rand.Reader, keyID); err != nil {
+		return nil, err
+	}
 
 	k := PrivateKey{
-		KeyID:      base64BigInt(pk.PublicKey.N),
+		KeyID:      hex.EncodeToString(keyID),
 		PrivateKey: pk,
 	}
 
 	return &k, nil
-}
-
-func base64BigInt(b *big.Int) string {
-	return base64.URLEncoding.EncodeToString(b.Bytes())
 }

--- a/key/key_test.go
+++ b/key/key_test.go
@@ -87,3 +87,17 @@ func TestPublicKeyMarshalJSON(t *testing.T) {
 		t.Errorf("got != want:\n%s\n%s", got, want)
 	}
 }
+
+func TestGeneratePrivateKeyIDs(t *testing.T) {
+	key1, err := GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("GeneratePrivateKey(): %v", err)
+	}
+	key2, err := GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("GeneratePrivateKey(): %v", err)
+	}
+	if key1.KeyID == key2.KeyID {
+		t.Fatalf("expected different keys to have different key IDs")
+	}
+}


### PR DESCRIPTION
Use shorter KeyIDs to reduce the overall size of JWTs produced by
this package.

The "kid" field value is unspecified and only exists to uniquely
identity keys in a JSONKeySet.[0] Therefore changing how we
generate this value shouldn't impact any existing programs.

This addresses coreos/dex#474

[0] https://tools.ietf.org/html/rfc7517#section-4.5

cc @chancez @sym3tri 