### PR TITLE
jose: use constant time comparison for HMAC verification

### DIFF
--- a/jose/sig_hmac.go
+++ b/jose/sig_hmac.go
@@ -1,7 +1,6 @@
 package jose
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/hmac"
 	_ "crypto/sha256"
@@ -44,7 +43,9 @@ func (v *VerifierHMAC) Alg() string {
 func (v *VerifierHMAC) Verify(sig []byte, data []byte) error {
 	h := hmac.New(v.Hash.New, v.Secret)
 	h.Write(data)
-	if !bytes.Equal(sig, h.Sum(nil)) {
+	// hmac.Equal compares two hmacs but does it in constant time to mitigating time
+	// based attacks. See #98
+	if !hmac.Equal(sig, h.Sum(nil)) {
 		return errors.New("invalid hmac signature")
 	}
 	return nil


### PR DESCRIPTION
This mirrors similar logic in square/go-jose[0] and dgrijalva/jwt-go[1].

[0] https://github.com/square/go-jose/blob/5848f914/symmetric.go#L317-L324
[1] https://github.com/dgrijalva/jwt-go/blob/63734eae/hmac.go#L71

Closes #98