### PR TITLE
jose: use RSA PSS to Sign and Verify

### DIFF
--- a/jose/sig_rsa.go
+++ b/jose/sig_rsa.go
@@ -19,7 +19,7 @@ type SignerRSA struct {
 }
 
 func NewVerifierRSA(jwk JWK) (*VerifierRSA, error) {
-	if jwk.Alg != "" && jwk.Alg != "RS256" {
+	if jwk.Alg != "" && jwk.Alg != "PS256" {
 		return nil, fmt.Errorf("unsupported key algorithm %q", jwk.Alg)
 	}
 
@@ -51,17 +51,17 @@ func (v *VerifierRSA) ID() string {
 }
 
 func (v *VerifierRSA) Alg() string {
-	return "RS256"
+	return "PS256"
 }
 
 func (v *VerifierRSA) Verify(sig []byte, data []byte) error {
 	h := v.Hash.New()
 	h.Write(data)
-	return rsa.VerifyPKCS1v15(&v.PublicKey, v.Hash, h.Sum(nil), sig)
+	return rsa.VerifyPSS(&v.PublicKey, v.Hash, h.Sum(nil), sig, &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
 }
 
 func (s *SignerRSA) Sign(data []byte) ([]byte, error) {
 	h := s.Hash.New()
 	h.Write(data)
-	return rsa.SignPKCS1v15(rand.Reader, &s.PrivateKey, s.Hash, h.Sum(nil))
+	return rsa.SignPSS(rand.Reader, &s.PrivateKey, s.Hash, h.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
 }


### PR DESCRIPTION
Even though the standard points to PKCS1v15 as the recommended algorithm it has its flaws. Quoting the go documentation:

The original specification for encryption and signatures with RSA is PKCS#1 and the terms "RSA encryption" and "RSA signatures" by default refer to PKCS#1 version 1.5. However, that specification has flaws and new designs should use version two, usually called by just OAEP and PSS, where possible.

This commit changes the methods Verify and Sign to use PSS instead of PKCS1v15.

References:
- [Bleichenbacher's Paper: Chosen Ciphertext Attacks Against Protocols Based on the RSA Encryption Standard PKCS #1](http://archiv.infsec.ethz.ch/education/fs08/secsem/bleichenbacher98.pdf)
- [Coron et all. Paper: New Attacks on PKCS#1 v1.5 Encryption](https://www.iacr.org/archive/eurocrypt2000/1807/18070374-new.pdf)