### PR TITLE
Updating a function name for better readability

### DIFF
--- a/jose/jwt_test.go
+++ b/jose/jwt_test.go
@@ -53,7 +53,7 @@ func TestParseJWT(t *testing.T) {
 	}
 }
 
-func TestNewJWTHeaderTyp(t *testing.T) {
+func TestNewJWTHeaderType(t *testing.T) {
 	jwt, err := NewJWT(JOSEHeader{}, Claims{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
Changed function name from 'TestNewJWTHeaderTyp' to 'TestNewJWTHeaderType' for better readability.