### PR TITLE
oidc/http: fix overflow in cache control

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -80,7 +80,7 @@ func cacheControlMaxAge(hdr string) (time.Duration, bool, error) {
 			return 0, false, nil
 		}
 
-		return time.Duration(age) * time.Second, true, nil
+		return time.Duration(age), true, nil
 	}
 
 	return 0, false, nil


### PR DESCRIPTION
fixes: #106

This commit addresses an issue where the cache control header returns a
ttl that overflows, causing bad behavior. This issue results in keys
being synced too frequently.