### PR TITLE
oidc/client: allow client to be copied

### DIFF
--- a/oidc/client.go
+++ b/oidc/client.go
@@ -606,6 +606,26 @@ type Client struct {
 	lastKeySetSync  time.Time
 }
 
+// CopyWithConfig will produce a copy of the existing client using
+// the given configuration. This is useful in scenarios where
+// a client has been initialized and synchonized with an OIDC
+// provider and now a new client is needed but we do not want to
+// re-synchronize.
+func (c *Client) CopyWithConfig(config *ClientConfig) (*Client, error) {
+	copy, err := NewClient(*config)
+	if err != nil {
+		return nil, err
+	}
+
+	c.keySetSyncMutex.Lock()
+	defer c.keySetSyncMutex.Unlock()
+
+	copy.keySet = c.keySet
+	copy.lastKeySetSync = c.lastKeySetSync
+
+	return copy, nil
+}
+
 func (c *Client) Healthy() error {
 	now := time.Now().UTC()
 


### PR DESCRIPTION
This commit adds new functionality to the client package of go-oidc that
allows an oidc client to be copied with a new configuration. This allows
us to reuse a client that has already been synchronized to an oidc
provider but with a new configuration. An example usage for this would
be a multi-tenant application that proxies authentication requests on
behalf of various clients that all use the same provider. Normally, the
proxy application would need to create a new `oidc/client` every time the
context changes and then synchronize this client with the provider to
retrieve the keys. This results in considerable extra latency. Instead,
the proxy application should be able to create a client and synchronize
keys once at launch and then copy the client along with its keys as it
needs while updating keys only as often as required by the cache
headers.