### PR TITLE
jose: use base64 raw URL encoding for modulus and exponent

### DIFF
--- a/jose/jwk.go
+++ b/jose/jwk.go
@@ -104,7 +104,7 @@ func encodeExponent(e int) string {
 			break
 		}
 	}
-	return base64.URLEncoding.EncodeToString(b[idx:])
+	return base64.RawURLEncoding.EncodeToString(b[idx:])
 }
 
 // Turns a URL encoded modulus of a key into a big int.
@@ -119,7 +119,7 @@ func decodeModulus(n string) (*big.Int, error) {
 }
 
 func encodeModulus(n *big.Int) string {
-	return base64.URLEncoding.EncodeToString(n.Bytes())
+	return base64.RawURLEncoding.EncodeToString(n.Bytes())
 }
 
 // decodeBase64URLPaddingOptional decodes Base64 whether there is padding or not.


### PR DESCRIPTION
Per JWS rfc7515 (Section 2. Terminology, Base64url Encoding), all
trailing '=' characters should be omitted. coreos/go-oidc/jose doesn't
implement this requirement.

While this was Ok when coreos/go-oidc/jose was used on both client and
server side, or when it was used on client side only (due to
decodeBase64URLPaddingOptional function), it stopped working when
go-oidc/jose is used on server side and stricter implementation of JWS
is used on the client side (notable, square/go-jose.v2 which is used by
new coreos/go-oidc package).

By following the RFC more strictly on the encoding side we:
  - allow to use new go-oidc package on the client side with
    DEX server v1, which relies on old go-oidc package;
  - don't break compatibility with existing software, as decoding
    handles both padded and unpadded messages.

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>