### PR TITLE
Use a token-aware HTTP client for UserInfo

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -161,7 +161,19 @@ func (p *Provider) UserInfo(ctx context.Context, tokenSource oauth2.TokenSource)
 	if p.userInfoURL == "" {
 		return nil, errors.New("oidc: user info endpoint is not supported by this provider")
 	}
-	resp, err := clientFromContext(ctx).Get(p.userInfoURL)
+
+	req, err := http.NewRequest("GET", p.userInfoURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("oidc: create GET request: %v", err)
+	}
+
+	token, err := tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("oidc: get access token: %v", err)
+	}
+	token.SetAuthHeader(req)
+
+	resp, err := clientFromContext(ctx).Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It seem that the current `UserInfo` function does not use the `tokenSource` to authenticate properly with the `/userinfo` endpoint (indeed `tokenSource` is not used at all in the `UserInfo` function. This PR replaces the `clientFromContext` call with an [`oauth2.NewClient`](https://godoc.org/golang.org/x/oauth2#NewClient) call that returns a token-aware HTTP client.

There are several other approaches that resolve non-authentication issue, such as:
* setting the client in the context and retaining the call to `clientFromContext`
* using the `oauth2.SetAuthHeader()` for the request that is passed to the HTTP client returned from `clientFromContext`

The latter option will always respect the HTTP client set by the context, but [the `SetAuthHeader` docs mention](https://github.com/golang/oauth2/blob/master/token.go#L78) that "... this method is unnecessary when using Transport or an HTTP Client returned by this package."

I'm not sure whether my proposed approach is optimal, and I'm happy to discuss.