### PR TITLE
key: fix test fail introduced by e7893b34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
   - 1.6.3
 
 install:
- - go get -v -t github.com/coreos/go-oidc
+ - go get -v -t github.com/coreos/go-oidc/...
  - go get golang.org/x/tools/cmd/cover
  - go get github.com/golang/lint/golint
 

--- a/key/key_test.go
+++ b/key/key_test.go
@@ -76,7 +76,7 @@ func TestPublicKeyMarshalJSON(t *testing.T) {
 		Modulus:  big.NewInt(int64(17)),
 		Exponent: 65537,
 	}
-	want := `{"kid":"foo","kty":"RSA","alg":"RS256","use":"sig","e":"AQAB","n":"EQ=="}`
+	want := `{"kid":"foo","kty":"RSA","alg":"RS256","use":"sig","e":"AQAB","n":"EQ"}`
 	pubKey := NewPublicKey(k)
 	gotBytes, err := pubKey.MarshalJSON()
 	if err != nil {

--- a/test
+++ b/test
@@ -9,7 +9,7 @@ LINTABLE=$( go list -tags=golint -f '
   {{ range $i, $file := .TestGoFiles -}}
     {{ $file }} {{ end }}' github.com/coreos/go-oidc )
 
-go test -v -i -race github.com/coreos/go-oidc
-go test -v -race github.com/coreos/go-oidc
+go test -v -i -race github.com/coreos/go-oidc/...
+go test -v -race github.com/coreos/go-oidc/...
 golint $LINTABLE
-go vet github.com/coreos/go-oidc
+go vet github.com/coreos/go-oidc/...


### PR DESCRIPTION
Commit e7893b34 changed the way keys' exponent and modulus are encoded,
but didn't fix the test to expect new format.

Fix the test here.

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>