### PR TITLE
*: Update ID token Validation according to OIDC spec.

### DIFF
--- a/example/idtoken/app.go
+++ b/example/idtoken/app.go
@@ -27,7 +27,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	verifier := provider.Verifier()
+	oidcConfig := &oidc.Config{
+		ClientID:       clientID,
+		SkipNonceCheck: true,
+	}
+	verifier := provider.Verifier(oidcConfig)
 
 	config := oauth2.Config{
 		ClientID:     clientID,

--- a/example/nonce/app.go
+++ b/example/nonce/app.go
@@ -23,10 +23,7 @@ var (
 
 const appNonce = "a super secret nonce"
 
-// Create a nonce source.
-type nonceSource struct{}
-
-func (n nonceSource) ClaimNonce(nonce string) error {
+func ClaimNonce(nonce string) error {
 	if nonce != appNonce {
 		return errors.New("unregonized nonce")
 	}
@@ -41,8 +38,12 @@ func main() {
 		log.Fatal(err)
 	}
 
+	oidcConfig := &oidc.Config{
+		ClientID:   clientID,
+		ClaimNonce: ClaimNonce,
+	}
 	// Use the nonce source to create a custom ID Token verifier.
-	nonceEnabledVerifier := provider.Verifier(oidc.VerifyNonce(nonceSource{}))
+	nonceEnabledVerifier := provider.Verifier(oidcConfig)
 
 	config := oauth2.Config{
 		ClientID:     clientID,

--- a/verify.go
+++ b/verify.go
@@ -17,53 +17,59 @@ import (
 // IDTokenVerifier provides verification for ID Tokens.
 type IDTokenVerifier struct {
 	keySet *remoteKeySet
-	config *verificationConfig
-}
-
-// verificationConfig is the unexported configuration for an IDTokenVerifier.
-//
-// Users interact with this struct using a VerificationOption.
-type verificationConfig struct {
+	config *Config
 	issuer string
-	// If provided, this value must be in the ID Token audiences.
-	audience string
-	// If not nil, check the expiry of the id token.
-	checkExpiry func() time.Time
-	// If specified, only these sets of algorithms may be used to sign the JWT.
-	requiredAlgs []string
-	// If not nil, don't verify nonce.
-	nonceSource NonceSource
 }
 
-// VerificationOption provides additional checks on ID Tokens.
-type VerificationOption interface {
-	// Unexport this method so other packages can't implement this interface.
-	updateConfig(c *verificationConfig)
+// Config is the configuration for an IDTokenVerifier.
+type Config struct {
+	// Expected audience of the token. For a majority of the cases this is expected to be
+	// the ID of the client that initialized the login flow. It may occasionally differ if
+	// the provider supports the authorizing party (azp) claim.
+	//
+	// If not provided, users must explicitly set SkipClientIDCheck.
+	ClientID string
+	// Method to verify the ID Token nonce. If a nonce is present and this method
+	// is nil, users must explicitly set SkipNonceCheck.
+	//
+	// If the ID Token nonce is empty, for example if the client didn't provide a nonce in
+	// the initial redirect, this may be nil.
+	ClaimNonce func(nonce string) error
+	// If specified, only this set of algorithms may be used to sign the JWT.
+	//
+	// Since many providers only support RS256, SupportedSigningAlgs defaults to this value.
+	SupportedSigningAlgs []string
+
+	// If true, no ClientID check performed. Must be true if ClientID field is empty.
+	SkipClientIDCheck bool
+	// If true, token expiry is not checked.
+	SkipExpiryCheck bool
+	// If true, nonce claim is not checked. Must be true if ClaimNonce field is empty.
+	SkipNonceCheck bool
+
+	// Time function to check Token expiry. Defaults to time.Now
+	Now func() time.Time
 }
 
 // Verifier returns an IDTokenVerifier that uses the provider's key set to verify JWTs.
 //
 // The returned IDTokenVerifier is tied to the Provider's context and its behavior is
 // undefined once the Provider's context is canceled.
-func (p *Provider) Verifier(options ...VerificationOption) *IDTokenVerifier {
-	config := &verificationConfig{issuer: p.issuer}
-	for _, option := range options {
-		option.updateConfig(config)
-	}
+func (p *Provider) Verifier(config *Config) *IDTokenVerifier {
 
-	return newVerifier(p.remoteKeySet, config)
+	return newVerifier(p.remoteKeySet, config, p.issuer)
 }
 
-func newVerifier(keySet *remoteKeySet, config *verificationConfig) *IDTokenVerifier {
-	// As discussed in the godocs for VerifrySigningAlg, because almost all providers
-	// only support RS256, default to only allowing it.
-	if len(config.requiredAlgs) == 0 {
-		config.requiredAlgs = []string{RS256}
+func newVerifier(keySet *remoteKeySet, config *Config, issuer string) *IDTokenVerifier {
+	// If SupportedSigningAlgs is empty defaults to only support RS256.
+	if len(config.SupportedSigningAlgs) == 0 {
+		config.SupportedSigningAlgs = []string{RS256}
 	}
 
 	return &IDTokenVerifier{
 		keySet: keySet,
 		config: config,
+		issuer: issuer,
 	}
 }
 
@@ -89,7 +95,7 @@ func contains(sli []string, ele string) bool {
 }
 
 // Verify parses a raw ID Token, verifies it's been signed by the provider, preforms
-// any additional checks passed as VerifictionOptions, and returns the payload.
+// any additional checks depending on the Config, and returns the payload.
 //
 // See: https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
 //
@@ -134,20 +140,31 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 	}
 
 	// Check issuer.
-	if t.Issuer != v.config.issuer {
-		return nil, fmt.Errorf("oidc: id token issued by a different provider, expected %q got %q", v.config.issuer, t.Issuer)
+	if t.Issuer != v.issuer {
+		return nil, fmt.Errorf("oidc: id token issued by a different provider, expected %q got %q", v.issuer, t.Issuer)
 	}
 
-	// If a client ID has been provided, make sure it's part of the audience.
-	if v.config.audience != "" {
-		if !contains(t.Audience, v.config.audience) {
-			return nil, fmt.Errorf("oidc: expected audience %q got %q", v.config.audience, t.Audience)
+	// If a client ID has been provided, make sure it's part of the audience. SkipClientIDCheck must be true if ClientID is empty.
+	//
+	// This check DOES NOT ensure that the ClientID is the party to which the ID Token was issued (i.e. Authorized party).
+	if !v.config.SkipClientIDCheck {
+		if v.config.ClientID != "" {
+			if !contains(t.Audience, v.config.ClientID) {
+				return nil, fmt.Errorf("oidc: expected audience %q got %q", v.config.ClientID, t.Audience)
+			}
+		} else {
+			return nil, fmt.Errorf("oidc: Invalid configuration. ClientID must be provided or SkipClientIDCheck must be set.")
 		}
 	}
 
-	// If a checkExpiry is specified, make sure token is not expired.
-	if v.config.checkExpiry != nil {
-		if t.Expiry.Before(v.config.checkExpiry()) {
+	// If a SkipExpiryCheck is false, make sure token is not expired.
+	if !v.config.SkipExpiryCheck {
+		now := time.Now
+		if v.config.Now != nil {
+			now = v.config.Now
+		}
+
+		if t.Expiry.Before(now()) {
 			return nil, fmt.Errorf("oidc: token is expired (Token Expiry: %v)", t.Expiry)
 		}
 	}
@@ -155,14 +172,14 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 	// If a set of required algorithms has been provided, ensure that the signatures use those.
 	var keyIDs, gotAlgs []string
 	for _, sig := range jws.Signatures {
-		if len(v.config.requiredAlgs) == 0 || contains(v.config.requiredAlgs, sig.Header.Algorithm) {
+		if len(v.config.SupportedSigningAlgs) == 0 || contains(v.config.SupportedSigningAlgs, sig.Header.Algorithm) {
 			keyIDs = append(keyIDs, sig.Header.KeyID)
 		} else {
 			gotAlgs = append(gotAlgs, sig.Header.Algorithm)
 		}
 	}
 	if len(keyIDs) == 0 {
-		return nil, fmt.Errorf("oidc: no signatures use a require algorithm, expected %q got %q", v.config.requiredAlgs, gotAlgs)
+		return nil, fmt.Errorf("oidc: no signatures use a supported algorithm, expected %q got %q", v.config.SupportedSigningAlgs, gotAlgs)
 	}
 
 	// Get keys from the remote key set. This may trigger a re-sync.
@@ -192,79 +209,22 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 
 	// Check the nonce after we've verified the token. We don't want to allow unverified
 	// payloads to trigger a nonce lookup.
-	if v.config.nonceSource != nil {
-		if err := v.config.nonceSource.ClaimNonce(t.Nonce); err != nil {
-			return nil, err
+	// If SkipNonceCheck is not set ClaimNonce cannot be Nil.
+	if !v.config.SkipNonceCheck && t.Nonce != "" {
+		if v.config.ClaimNonce != nil {
+			if err := v.config.ClaimNonce(t.Nonce); err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, fmt.Errorf("oidc: Invalid configuration. ClaimNonce must be provided or SkipNonceCheck must be set.")
 		}
 	}
 
 	return t, nil
 }
 
-// VerifyAudience ensures that an ID Token was issued for the specific client.
-//
-// Note that a verified token may be valid for other clients, as OpenID Connect allows a token to have
-// multiple audiences.
-func VerifyAudience(clientID string) VerificationOption {
-	return clientVerifier{clientID}
-}
-
-type clientVerifier struct {
-	clientID string
-}
-
-func (v clientVerifier) updateConfig(c *verificationConfig) {
-	c.audience = v.clientID
-}
-
-// VerifyExpiry ensures that an ID Token has not expired.
-func VerifyExpiry() VerificationOption {
-	return expiryVerifier{}
-}
-
-type expiryVerifier struct{}
-
-func (v expiryVerifier) updateConfig(c *verificationConfig) {
-	c.checkExpiry = time.Now
-}
-
-// VerifySigningAlg enforces that an ID Token is signed by a specific signing algorithm.
-//
-// Because so many providers only support RS256, if this verifiction option isn't used,
-// the IDTokenVerifier defaults to only allowing RS256.
-func VerifySigningAlg(allowedAlgs ...string) VerificationOption {
-	return algVerifier{allowedAlgs}
-}
-
-type algVerifier struct {
-	algs []string
-}
-
-func (v algVerifier) updateConfig(c *verificationConfig) {
-	c.requiredAlgs = v.algs
-}
-
 // Nonce returns an auth code option which requires the ID Token created by the
 // OpenID Connect provider to contain the specified nonce.
 func Nonce(nonce string) oauth2.AuthCodeOption {
 	return oauth2.SetAuthURLParam("nonce", nonce)
-}
-
-// NonceSource represents a source which can verify a nonce is valid and has not
-// been claimed before.
-type NonceSource interface {
-	ClaimNonce(nonce string) error
-}
-
-// VerifyNonce ensures that the ID Token contains a nonce which can be claimed by the nonce source.
-func VerifyNonce(source NonceSource) VerificationOption {
-	return nonceVerifier{source}
-}
-
-type nonceVerifier struct {
-	nonceSource NonceSource
-}
-
-func (n nonceVerifier) updateConfig(c *verificationConfig) {
-	c.nonceSource = n.nonceSource
 }

--- a/verify_test.go
+++ b/verify_test.go
@@ -20,8 +20,10 @@ func TestVerify(t *testing.T) {
 			idToken: idToken{
 				Issuer: "https://foo",
 			},
-			config: verificationConfig{
-				issuer: "https://foo",
+			config: Config{
+				SkipClientIDCheck: true,
+				SkipNonceCheck:    true,
+				SkipExpiryCheck:   true,
 			},
 			signKey: testKeyRSA_2048_0_Priv,
 			pubKeys: []jose.JSONWebKey{testKeyRSA_2048_0},
@@ -32,9 +34,9 @@ func TestVerify(t *testing.T) {
 				Issuer: "https://foo",
 				Expiry: jsonTime(time.Now().Add(-time.Hour)),
 			},
-			config: verificationConfig{
-				issuer:      "https://foo",
-				checkExpiry: time.Now,
+			config: Config{
+				SkipClientIDCheck: true,
+				SkipNonceCheck:    true,
 			},
 			signKey: testKeyRSA_2048_0_Priv,
 			pubKeys: []jose.JSONWebKey{testKeyRSA_2048_0},
@@ -45,23 +47,13 @@ func TestVerify(t *testing.T) {
 			idToken: idToken{
 				Issuer: "https://foo",
 			},
-			config: verificationConfig{
-				issuer: "https://foo",
+			config: Config{
+				SkipClientIDCheck: true,
+				SkipNonceCheck:    true,
+				SkipExpiryCheck:   true,
 			},
 			signKey: testKeyRSA_2048_0_Priv,
 			pubKeys: []jose.JSONWebKey{testKeyRSA_2048_1},
-			wantErr: true,
-		},
-		{
-			name: "invalid issuer",
-			idToken: idToken{
-				Issuer: "https://foo",
-			},
-			config: verificationConfig{
-				issuer: "https://bar",
-			},
-			signKey: testKeyRSA_2048_0_Priv,
-			pubKeys: []jose.JSONWebKey{testKeyRSA_2048_0},
 			wantErr: true,
 		},
 	}
@@ -78,9 +70,10 @@ func TestVerifyAudience(t *testing.T) {
 				Issuer:   "https://foo",
 				Audience: []string{"client1"},
 			},
-			config: verificationConfig{
-				issuer:   "https://foo",
-				audience: "client1",
+			config: Config{
+				ClientID:        "client1",
+				SkipNonceCheck:  true,
+				SkipExpiryCheck: true,
 			},
 			signKey: testKeyRSA_2048_0_Priv,
 			pubKeys: []jose.JSONWebKey{testKeyRSA_2048_0},
@@ -91,9 +84,10 @@ func TestVerifyAudience(t *testing.T) {
 				Issuer:   "https://foo",
 				Audience: []string{"client2"},
 			},
-			config: verificationConfig{
-				issuer:   "https://foo",
-				audience: "client1",
+			config: Config{
+				ClientID:        "client1",
+				SkipNonceCheck:  true,
+				SkipExpiryCheck: true,
 			},
 			signKey: testKeyRSA_2048_0_Priv,
 			pubKeys: []jose.JSONWebKey{testKeyRSA_2048_0},
@@ -105,9 +99,10 @@ func TestVerifyAudience(t *testing.T) {
 				Issuer:   "https://foo",
 				Audience: []string{"client2", "client1"},
 			},
-			config: verificationConfig{
-				issuer:   "https://foo",
-				audience: "client1",
+			config: Config{
+				ClientID:        "client1",
+				SkipNonceCheck:  true,
+				SkipExpiryCheck: true,
 			},
 			signKey: testKeyRSA_2048_0_Priv,
 			pubKeys: []jose.JSONWebKey{testKeyRSA_2048_0},
@@ -125,8 +120,10 @@ func TestVerifySigningAlg(t *testing.T) {
 			idToken: idToken{
 				Issuer: "https://foo",
 			},
-			config: verificationConfig{
-				issuer: "https://foo",
+			config: Config{
+				SkipClientIDCheck: true,
+				SkipNonceCheck:    true,
+				SkipExpiryCheck:   true,
 			},
 			signKey: testKeyRSA_2048_0_Priv,
 			signAlg: RS256, // By default we only support RS256.
@@ -137,8 +134,10 @@ func TestVerifySigningAlg(t *testing.T) {
 			idToken: idToken{
 				Issuer: "https://foo",
 			},
-			config: verificationConfig{
-				issuer: "https://foo",
+			config: Config{
+				SkipClientIDCheck: true,
+				SkipNonceCheck:    true,
+				SkipExpiryCheck:   true,
 			},
 			signKey: testKeyRSA_2048_0_Priv,
 			signAlg: RS512,
@@ -150,9 +149,11 @@ func TestVerifySigningAlg(t *testing.T) {
 			idToken: idToken{
 				Issuer: "https://foo",
 			},
-			config: verificationConfig{
-				issuer:       "https://foo",
-				requiredAlgs: []string{ES384},
+			config: Config{
+				SupportedSigningAlgs: []string{ES384},
+				SkipClientIDCheck:    true,
+				SkipNonceCheck:       true,
+				SkipExpiryCheck:      true,
 			},
 			signAlg: ES384,
 			signKey: testKeyECDSA_384_0_Priv,
@@ -163,9 +164,11 @@ func TestVerifySigningAlg(t *testing.T) {
 			idToken: idToken{
 				Issuer: "https://foo",
 			},
-			config: verificationConfig{
-				issuer:       "https://foo",
-				requiredAlgs: []string{RS256, ES384},
+			config: Config{
+				SkipClientIDCheck:    true,
+				SkipNonceCheck:       true,
+				SkipExpiryCheck:      true,
+				SupportedSigningAlgs: []string{RS256, ES384},
 			},
 			signAlg: ES384,
 			signKey: testKeyECDSA_384_0_Priv,
@@ -176,9 +179,11 @@ func TestVerifySigningAlg(t *testing.T) {
 			idToken: idToken{
 				Issuer: "https://foo",
 			},
-			config: verificationConfig{
-				issuer:       "https://foo",
-				requiredAlgs: []string{RS256, ES512},
+			config: Config{
+				SupportedSigningAlgs: []string{RS256, ES512},
+				SkipClientIDCheck:    true,
+				SkipNonceCheck:       true,
+				SkipExpiryCheck:      true,
 			},
 			signAlg: ES384,
 			signKey: testKeyECDSA_384_0_Priv,
@@ -201,7 +206,7 @@ type verificationTest struct {
 	// from the signingKey.
 	signAlg string
 
-	config  verificationConfig
+	config  Config
 	pubKeys []jose.JSONWebKey
 
 	wantErr bool
@@ -265,7 +270,7 @@ func (v verificationTest) run(t *testing.T) {
 	server := httptest.NewServer(newKeyServer(v.pubKeys...))
 	defer server.Close()
 
-	verifier := newVerifier(newRemoteKeySet(ctx, server.URL, now), &v.config)
+	verifier := newVerifier(newRemoteKeySet(ctx, server.URL, now), &v.config, "https://foo")
 
 	if _, err := verifier.Verify(ctx, token); err != nil {
 		if !v.wantErr {


### PR DESCRIPTION
Closes #128.

The current ID Token validation is driven by the VerificationOptions argument provided to the Verifier. Thus we do not implement some of "Must Checks" in the OIDC spec (https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation).

This change ensures that the ID Token validation process has stronger defaults, in turn making it more secure. We still provide the option to skip these default checks via the configuration attributes in the Config struct.

As a part of this change I also updated the example apps and the tests in verify_test.go.