### PR TITLE
special case google accounts issuer validation

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -201,19 +201,35 @@ func (p *Provider) UserInfo(ctx context.Context, tokenSource oauth2.TokenSource)
 // The ID Token only holds fields OpenID Connect requires. To access additional
 // claims returned by the server, use the Claims method.
 type IDToken struct {
-	// The URL of the server which issued this token. This will always be the same
-	// as the URL used for initial discovery.
+	// The URL of the server which issued this token. OpenID Connect
+	// requires this value always be identical to the URL used for
+	// initial discovery.
+	//
+	// Note: Because of a known issue with Google Accounts' implementation
+	// this value may differ when using Google.
+	//
+	// See: https://developers.google.com/identity/protocols/OpenIDConnect#obtainuserinfo
 	Issuer string
 
-	// The client, or set of clients, that this token is issued for.
+	// The client ID, or set of client IDs, that this token is issued for. For
+	// common uses, this is the client that initialized the auth flow.
+	//
+	// This package ensures the audience contains an expected value.
 	Audience []string
 
 	// A unique string which identifies the end user.
 	Subject string
 
+	// Expiry of the token. Ths package will not process tokens that have
+	// expired unless that validation is explicitly turned off.
+	Expiry time.Time
+	// When the token was issued by the provider.
 	IssuedAt time.Time
-	Expiry   time.Time
-	Nonce    string
+
+	// Initial nonce provided during the authentication redirect.
+	//
+	// If present, this package ensures this is a valid nonce.
+	Nonce string
 
 	// Raw payload of the id_token.
 	claims []byte


### PR DESCRIPTION
Google sometimes returns "accounts.google.com" instead of
"https://accounts.google.com". Special case this.

Originally we merged a new verification flag, but since this should
only be used with Google, and should always be on with Google, it
makes more sense for us to detect this case transparently.

Fixes #125

cc @ksswr @rithujohn191 