### PR TITLE
oidc: Expose Issuer on the OIDC Provider struct

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -143,6 +143,11 @@ func (p *Provider) Endpoint() oauth2.Endpoint {
 	return oauth2.Endpoint{AuthURL: p.authURL, TokenURL: p.tokenURL}
 }
 
+// Issuer returns the OAuth2 issuer claim for the given provider.
+func (p *Provider) Issuer() string {
+	return p.issuer
+}
+
 // UserInfo represents the OpenID Connect userinfo claims.
 type UserInfo struct {
 	Subject       string `json:"sub"`


### PR DESCRIPTION
- I have a couple places where i'm keeping a Provider around in other structs, and I'd like to get at the original Issuer, seems easy to just expose this as another method?