### PR TITLE
fix(http): Allows 0 as an `Expires` header value

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -91,7 +91,12 @@ func expires(date, expires string) (time.Duration, bool, error) {
 		return 0, false, nil
 	}
 
-	te, err := time.Parse(time.RFC1123, expires)
+	var te time.Time
+	var err error
+	if expires == "0" {
+		return 0, false, nil
+	}
+	te, err = time.Parse(time.RFC1123, expires)
 	if err != nil {
 		return 0, false, err
 	}

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -177,6 +177,13 @@ func TestExpiresPass(t *testing.T) {
 			wantTTL: 0,
 			wantOK:  false,
 		},
+		// Expires set to false
+		{
+			date:    "Thu, 01 Dec 1983 22:00:00 GMT",
+			exp:     "0",
+			wantTTL: 0,
+			wantOK:  false,
+		},
 		// Expires < Date
 		{
 			date:    "Fri, 02 Dec 1983 01:00:00 GMT",


### PR DESCRIPTION
This is allowed by the RFC and is common with a few OIDC providers.

Partially addresses #136 as a temporary solution until k8s uses the top level package

/cc @ericchiang 