### PR TITLE
NewVerifier: fix defaulting of RS256

### DIFF
--- a/verify_test.go
+++ b/verify_test.go
@@ -252,7 +252,7 @@ func (v verificationTest) runGetToken(t *testing.T) *IDToken {
 	} else {
 		ks = &testVerifier{v.verificationKey.jwk()}
 	}
-	verifier := newVerifier(ks, &v.config, issuer)
+	verifier := NewVerifier(issuer, ks, &v.config)
 
 	idToken, err := verifier.Verify(ctx, token)
 	if err != nil {


### PR DESCRIPTION
When NewVerifier was introduced, it forgot to default the
SupportedSigningAlgs value in the verification config. This means
an attacker can pass a token signed with any asymmetric "alg" value.

This isn't a P0 because the public key set from the provider should
only return asymmetric keys, so an attacker can't sneak a token
signed with a symmetric algorithm like HS512. RS256 is also the
weakest hash supported by square/go-jose, so you can't downgrade to
a weaker signing hash. Additionally, using jose.ParseSigned ensures
tokens encrypted with algorithms like A128GCM are rejected.

Additionally NewVerifier isn't expected to be used commonly. It's
mostly for testing (though that doesn't reduce the severity).

Unify the verifier creation code and make it impossible to pass an
empty list of SupportedSigningAlgs.

No new tests because the Verify path is already tested.