### PR TITLE
verify: added skip verify issuer

### DIFF
--- a/verify_test.go
+++ b/verify_test.go
@@ -45,6 +45,18 @@ func TestVerify(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "skip verify invalid issuer",
+			issuer:  "https://bar",
+			idToken: `{"iss":"https://foo"}`,
+			config: Config{
+				SkipClientIDCheck: true,
+				SkipExpiryCheck:   true,
+				SkipVerifyIssuer: true,
+			},
+			signKey: newRSAKey(t),
+			wantErr: false,
+		},
+		{
 			name:    "invalid sig",
 			idToken: `{"iss":"https://foo"}`,
 			config: Config{


### PR DESCRIPTION
In order to be able to work with misconfigured auth servers I added this config flag to disable the issuer check. By default issuer check will be enabled. The special handling for google servers remains untouched.