### PR TITLE
verify: added skip verify issuer

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -49,6 +49,8 @@ type Config struct {
 	SkipClientIDCheck bool
 	// If true, token expiry is not checked.
 	SkipExpiryCheck bool
+	// If true, it is not checked if the issuers match
+	SkipVerifyIssuer bool
 
 	// Time function to check Token expiry. Defaults to time.Now
 	Now func() time.Time
@@ -145,14 +147,16 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 	}
 
 	// Check issuer.
-	if t.Issuer != v.issuer {
-		// Google sometimes returns "accounts.google.com" as the issuer claim instead of
-		// the required "https://accounts.google.com". Detect this case and allow it only
-		// for Google.
-		//
-		// We will not add hooks to let other providers go off spec like this.
-		if !(v.issuer == issuerGoogleAccounts && t.Issuer == issuerGoogleAccountsNoScheme) {
-			return nil, fmt.Errorf("oidc: id token issued by a different provider, expected %q got %q", v.issuer, t.Issuer)
+	if !v.config.SkipVerifyIssuer {
+    	if t.Issuer != v.issuer {
+			// Google sometimes returns "accounts.google.com" as the issuer claim instead of
+			// the required "https://accounts.google.com". Detect this case and allow it only
+			// for Google.
+			//
+			// We will not add hooks to let other providers go off spec like this.
+			if !(v.issuer == issuerGoogleAccounts && t.Issuer == issuerGoogleAccountsNoScheme) {
+				return nil, fmt.Errorf("oidc: id token issued by a different provider, expected %q got %q", v.issuer, t.Issuer)
+			}
 		}
 	}
 

--- a/verify_test.go
+++ b/verify_test.go
@@ -40,6 +40,18 @@ func TestVerify(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "skip verify invalid issuer",
+			issuer:  "https://bar",
+			idToken: `{"iss":"https://foo"}`,
+			config: Config{
+				SkipClientIDCheck: true,
+				SkipExpiryCheck:   true,
+				SkipVerifyIssuer: true,
+			},
+			signKey: newRSAKey(t),
+			wantErr: false,
+		},
+		{
 			name:    "invalid sig",
 			idToken: `{"iss":"https://foo"}`,
 			config: Config{


### PR DESCRIPTION
In order to be able to work with misconfigured auth servers I added this config flag to disable the issuer check. By default issuer check will be enabled. The special handling for google servers remains untouched.