### PR TITLE
jwks: Don't store context in remoteKeySet

### DIFF
--- a/jwks.go
+++ b/jwks.go
@@ -31,22 +31,19 @@ const keysExpiryDelta = 30 * time.Second
 //
 // The returned KeySet is a long lived verifier that caches keys based on cache-control
 // headers. Reuse a common remote key set instead of creating new ones as needed.
-//
-// The behavior of the returned KeySet is undefined once the context is canceled.
-func NewRemoteKeySet(ctx context.Context, jwksURL string) KeySet {
-	return newRemoteKeySet(ctx, jwksURL, time.Now)
+func NewRemoteKeySet(jwksURL string) KeySet {
+	return newRemoteKeySet(jwksURL, time.Now)
 }
 
-func newRemoteKeySet(ctx context.Context, jwksURL string, now func() time.Time) *remoteKeySet {
+func newRemoteKeySet(jwksURL string, now func() time.Time) *remoteKeySet {
 	if now == nil {
 		now = time.Now
 	}
-	return &remoteKeySet{jwksURL: jwksURL, ctx: ctx, now: now}
+	return &remoteKeySet{jwksURL: jwksURL, now: now}
 }
 
 type remoteKeySet struct {
 	jwksURL string
-	ctx     context.Context
 	now     func() time.Time
 
 	// guard all other fields
@@ -160,7 +157,7 @@ func (r *remoteKeySet) keysFromRemote(ctx context.Context) ([]jose.JSONWebKey, e
 		// once the goroutine is done.
 		go func() {
 			// Sync keys and finish inflight when that's done.
-			keys, expiry, err := r.updateKeys()
+			keys, expiry, err := r.updateKeys(ctx)
 
 			r.inflight.done(keys, err)
 
@@ -189,13 +186,13 @@ func (r *remoteKeySet) keysFromRemote(ctx context.Context) ([]jose.JSONWebKey, e
 	}
 }
 
-func (r *remoteKeySet) updateKeys() ([]jose.JSONWebKey, time.Time, error) {
+func (r *remoteKeySet) updateKeys(ctx context.Context) ([]jose.JSONWebKey, time.Time, error) {
 	req, err := http.NewRequest("GET", r.jwksURL, nil)
 	if err != nil {
 		return nil, time.Time{}, fmt.Errorf("oidc: can't create request: %v", err)
 	}
 
-	resp, err := doRequest(r.ctx, req)
+	resp, err := doRequest(ctx, req)
 	if err != nil {
 		return nil, time.Time{}, fmt.Errorf("oidc: get keys failed %v", err)
 	}

--- a/jwks_test.go
+++ b/jwks_test.go
@@ -146,7 +146,7 @@ func testKeyVerify(t *testing.T, good, bad *signingKey, verification ...*signing
 	s := httptest.NewServer(&keyServer{keys: keySet})
 	defer s.Close()
 
-	rks := newRemoteKeySet(ctx, s.URL, nil)
+	rks := newRemoteKeySet(s.URL, nil)
 
 	// Ensure the token verifies.
 	gotPayload, err := rks.verify(ctx, jws)
@@ -206,7 +206,7 @@ func TestCacheControl(t *testing.T) {
 	s := httptest.NewServer(server)
 	defer s.Close()
 
-	rks := newRemoteKeySet(ctx, s.URL, func() time.Time { return now })
+	rks := newRemoteKeySet(s.URL, func() time.Time { return now })
 
 	if _, err := rks.verify(ctx, jws1); err != nil {
 		t.Errorf("failed to verify valid signature: %v", err)

--- a/oidc.go
+++ b/oidc.go
@@ -129,7 +129,7 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 		tokenURL:     p.TokenURL,
 		userInfoURL:  p.UserInfoURL,
 		rawClaims:    body,
-		remoteKeySet: NewRemoteKeySet(ctx, p.JWKSURL),
+		remoteKeySet: NewRemoteKeySet(p.JWKSURL),
 	}, nil
 }
 


### PR DESCRIPTION
The docs for the context package say:

    Do not store Contexts inside a struct type; instead, pass a Context
    explicitly to each function that needs it.

Previously the context passed to NewProvider would get stashed away in
the remoteKeySet structure, then maybe used later. If the context that
created the provider had been cancelled, keys could not be fetched.

For a use case where this is bad, consider the user of this library is
an HTTP server. It has a REST endpoint which can configure OIDC
providers to use for authentication. It then has other endpoints that
use those providers. When the configure endpoint is called, it creates a
context and calls NewProvider(). When the handler for the configure
endpoint is done, it cancels the context.

When the provider returned by NewProvider() is subsequently used, keys
can not be verified: they fail with "context canceled".

Fortunately the keys get updated from Verify(), which already takes a
context. So we can just use that. This does mean if the context is being
used to change the default HTTP client it's necessary to do it on the
context passed to Verify() as well as NewProvider().