### PR TITLE
DecodedClaimsJSON endpoint for userinfo

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -176,6 +176,19 @@ func (u *UserInfo) Claims(v interface{}) error {
 	return json.Unmarshal(u.claims, v)
 }
 
+// EncodedClaimsJSON returns claims JSON in base64-encoded form
+func (u *UserInfo) EncodedClaimsJSON() (json.RawMessage, error) {
+	if u.claims == nil {
+		return nil, errors.New("oidc: claims not set")
+	}
+	cj, err := json.Marshal(u.claims)
+	if err != nil {
+		return nil, errors.New("oidc: problem marshalling claims to JSON: " + err.Error())
+	}
+
+	return cj, nil
+}
+
 // UserInfo uses the token source to query the provider's user info endpoint.
 func (p *Provider) UserInfo(ctx context.Context, tokenSource oauth2.TokenSource) (*UserInfo, error) {
 	if p.userInfoURL == "" {


### PR DESCRIPTION
New DecodedClaimsJSON() endpoint for UserInfo. Endpoint returns the JSON string as base64-encoded json.RawMessage, to easily add userinfo as header for other service endpoints.

As most [standard claims](http://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims) aren't included in UserInfo struct, and the OIDC standard allows people also to define their own, UserInfo.claims is the most useful part of the userinfo model, so it's good to offer a simple endpoint for fetching the data.

If needed, I can make suggested changes to the code (if you wish to have a different name for it, for example "Base64ClaimsJSON()"), or you can freely do so yourselves if you want to.