### PR TITLE
Remove client_secret POST parameter for basic auth method

### DIFF
--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -257,7 +257,6 @@ func (c *Client) RequestToken(grantType, value string) (result TokenResponse, er
 	v := c.commonURLValues()
 
 	v.Set("grant_type", grantType)
-	v.Set("client_secret", c.creds.Secret)
 	switch grantType {
 	case GrantTypeAuthCode:
 		v.Set("code", value)


### PR DESCRIPTION
My custom IdP returns error, when I want to exchange a code for the access token:
```
invalid_request: Request requires a valid client authentication method
```
Root cause: `go-oidc v1` sends 2 auth methods (post+basic auth) in one request - it is a violation of https://tools.ietf.org/html/rfc6749#section-2.3

> the client MUST NOT use more than one authentication method in each request

More details about the issue: https://github.com/gambol99/keycloak-proxy/issues/336