### PR TITLE
fix: handle -1 HTTP Expires header

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -93,7 +93,7 @@ func expires(date, expires string) (time.Duration, bool, error) {
 
 	var te time.Time
 	var err error
-	if expires == "0" {
+	if expires == "0" || expires == "-1" {
 		return 0, false, nil
 	}
 	te, err = time.Parse(time.RFC1123, expires)

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -177,10 +177,17 @@ func TestExpiresPass(t *testing.T) {
 			wantTTL: 0,
 			wantOK:  false,
 		},
-		// Expires set to false
+		// Expires set to false (0)
 		{
 			date:    "Thu, 01 Dec 1983 22:00:00 GMT",
 			exp:     "0",
+			wantTTL: 0,
+			wantOK:  false,
+		},
+		// Expires set to false (-1)
+		{
+			date:    "Thu, 01 Dec 1983 22:00:00 GMT",
+			exp:     "-1",
 			wantTTL: 0,
 			wantOK:  false,
 		},


### PR DESCRIPTION
Greetings !

While using this library on an Azure AD endpoint, I noticed Microsoft sending me `Expires: -1` in response to the OIDC Discovery endpoint. When I saw that you were handling the `0` case, I thought I'd also add the `-1` case as well.

Let me know what you think.

Thanks :smile: 