### PR TITLE
https://github.com/coreos/go-oidc/issues/219

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -91,10 +91,10 @@ type providerJSON struct {
 
 // NewProvider uses the OpenID Connect discovery mechanism to construct a Provider.
 //
-// The issuer is the URL identifier for the service. For example: "https://accounts.google.com"
+// The authority is the URL identifier for the service. For example: "https://accounts.google.com"
 // or "https://login.salesforce.com".
-func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
-	wellKnown := strings.TrimSuffix(issuer, "/") + "/.well-known/openid-configuration"
+func NewProvider(ctx context.Context, authority string) (*Provider, error) {
+	wellKnown := strings.TrimSuffix(authority, "/") + "/.well-known/openid-configuration"
 	req, err := http.NewRequest("GET", wellKnown, nil)
 	if err != nil {
 		return nil, err
@@ -120,9 +120,6 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 		return nil, fmt.Errorf("oidc: failed to decode provider discovery object: %v", err)
 	}
 
-	if p.Issuer != issuer {
-		return nil, fmt.Errorf("oidc: issuer did not match the issuer returned by provider, expected %q got %q", issuer, p.Issuer)
-	}
 	return &Provider{
 		issuer:       p.Issuer,
 		authURL:      p.AuthURL,


### PR DESCRIPTION
issuer is not to be known by the client, it is given by /.well-known/openid-configuration

https://github.com/coreos/go-oidc/issues/219
