### PR TITLE
Fix issues with long-held reference to context passed to NewProvider

### DIFF
--- a/jwks_test.go
+++ b/jwks_test.go
@@ -146,7 +146,7 @@ func testKeyVerify(t *testing.T, good, bad *signingKey, verification ...*signing
 	s := httptest.NewServer(&keyServer{keys: keySet})
 	defer s.Close()
 
-	rks := newRemoteKeySet(ctx, s.URL, nil)
+	rks := newRemoteKeySet(ctx, http.DefaultClient, s.URL, nil)
 
 	// Ensure the token verifies.
 	gotPayload, err := rks.verify(ctx, jws)
@@ -206,7 +206,7 @@ func TestCacheControl(t *testing.T) {
 	s := httptest.NewServer(server)
 	defer s.Close()
 
-	rks := newRemoteKeySet(ctx, s.URL, func() time.Time { return now })
+	rks := newRemoteKeySet(ctx, http.DefaultClient, s.URL, func() time.Time { return now })
 
 	if _, err := rks.verify(ctx, jws1); err != nil {
 		t.Errorf("failed to verify valid signature: %v", err)


### PR DESCRIPTION
Instead of using a context to bound key fetch requests, allow the user to pass
a custom HTTP client to control timeout behavior. There are no behavioral
changes for the now-deprecated NewRemoteKeySet function.

Change NewProvider to only use the passed context for the discovery HTTP
request and for extracting an HTTP client to be used in the remote key set.

Enforce a default HTTP request timeout of 30 seconds if the client for remote
key fetches does not specify a timeout.

Fixes #214

NOTE: See #214 for a discussion of the issue. This change aims at being minimally disruptive (of course some behavioral change is inevitable) without taking any features that specifying a context entails away. This motivates the choice to pass an `*http.Client` to `NewRemoteKeySetWithClient` in favor of a simpler option such as a simple `timeout time.Duration`.