### PR TITLE
Ignore trailing slash when checking the issuer from the OpenID discovery URL

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -111,7 +111,8 @@ var supportedAlgorithms = map[string]bool{
 // The issuer is the URL identifier for the service. For example: "https://accounts.google.com"
 // or "https://login.salesforce.com".
 func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
-	wellKnown := strings.TrimSuffix(issuer, "/") + "/.well-known/openid-configuration"
+	issuer = strings.TrimSuffix(issuer, "/")
+	wellKnown := issuer + "/.well-known/openid-configuration"
 	req, err := http.NewRequest("GET", wellKnown, nil)
 	if err != nil {
 		return nil, err
@@ -137,8 +138,9 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 		return nil, fmt.Errorf("oidc: failed to decode provider discovery object: %v", err)
 	}
 
-	if p.Issuer != issuer {
-		return nil, fmt.Errorf("oidc: issuer did not match the issuer returned by provider, expected %q got %q", issuer, p.Issuer)
+	discoveredIssuer := strings.TrimSuffix(p.Issuer, "/")
+	if discoveredIssuer != issuer {
+		return nil, fmt.Errorf("oidc: issuer did not match the issuer returned by provider, expected %q got %q", issuer, discoveredIssuer)
 	}
 	var algs []string
 	for _, a := range p.Algorithms {

--- a/oidc_test.go
+++ b/oidc_test.go
@@ -257,7 +257,7 @@ func TestNewProvider(t *testing.T) {
 					return
 				}
 				w.Header().Set("Content-Type", "application/json")
-				io.WriteString(w, strings.ReplaceAll(test.data, "ISSUER", issuer))
+				io.WriteString(w, strings.ReplaceAll(test.data, "ISSUER", strings.TrimSuffix(issuer, "/")))
 			}
 			s := httptest.NewServer(http.HandlerFunc(hf))
 			defer s.Close()


### PR DESCRIPTION
## What

Previously the NewProvider function threw an error if the passed `issuer`
variable and the `issuer` parameter from the discovery URL didn't exactly
match.
This should not happen if the only difference is a trailing slash.

This fixes https://github.com/coreos/go-oidc/issues/238