### PR TITLE
handle UserInfo.email_verified as a string

### DIFF
--- a/oidc_test.go
+++ b/oidc_test.go
@@ -2,6 +2,7 @@ package oidc
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -295,5 +296,16 @@ func TestNewProvider(t *testing.T) {
 					p.algorithms, test.wantAlgorithms)
 			}
 		})
+	}
+}
+
+func TestStringEmailVerified(t *testing.T) {
+	var u UserInfo
+	err := json.Unmarshal([]byte(`{ "email_verified": "true" }`), &u)
+	if err != nil {
+		t.Error(err)
+	}
+	if !u.EmailVerified {
+		t.Error("expected email_verified to be parsed in json")
 	}
 }


### PR DESCRIPTION
We were using this library to interface with AWS Cognito and received this error message:

```json: cannot unmarshal string into Go struct field UserInfo.email_verified of type bool```

So apparently they've decided to return the `email_verified` field as a string instead of a bool. 

These changes make the code more tolerant of the type of data so that it can handle both cases.