### PR TITLE
Support signed jwt userinfo response

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -230,6 +230,14 @@ func (p *Provider) UserInfo(ctx context.Context, tokenSource oauth2.TokenSource)
 		return nil, fmt.Errorf("%s: %s", resp.Status, body)
 	}
 
+	if strings.EqualFold(resp.Header.Get("Content-Type"), "application/jwt") {
+		payload, err := p.remoteKeySet.VerifySignature(ctx, string(body))
+		if err != nil {
+			return nil, fmt.Errorf("oidc: invalid userinfo jwt signature %v", err)
+		}
+		body = payload
+	}
+
 	var userInfo UserInfo
 	if err := json.Unmarshal(body, &userInfo); err != nil {
 		return nil, fmt.Errorf("oidc: failed to decode userinfo: %v", err)


### PR DESCRIPTION
Hi.

We're using one of the servers which returns `userinfo` response as a signed JWT.
This is, of course, fine according to the spec https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse

This PR adds support for signed JWT `userinfo` responses.

I was wondering how to approach it, and wanted to add it in a way that still works for everyone using this library for `userinfo` fetching without breaking anything.

Added a check based on the `Content-Type` header `application/jwt` which seams reasonable.

Additionally, I've added tests checking that the UserInfo is generated properly from regular JSON and JWT.
