### PR TITLE
Userinfo - handling charset in Content-Type header

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -230,7 +230,9 @@ func (p *Provider) UserInfo(ctx context.Context, tokenSource oauth2.TokenSource)
 		return nil, fmt.Errorf("%s: %s", resp.Status, body)
 	}
 
-	if strings.EqualFold(resp.Header.Get("Content-Type"), "application/jwt") {
+	ct := resp.Header.Get("Content-Type")
+	mediaType, _, parseErr := mime.ParseMediaType(ct)
+	if parseErr == nil && mediaType == "application/jwt" {
 		payload, err := p.remoteKeySet.VerifySignature(ctx, string(body))
 		if err != nil {
 			return nil, fmt.Errorf("oidc: invalid userinfo jwt signature %v", err)

--- a/oidc_test.go
+++ b/oidc_test.go
@@ -399,6 +399,21 @@ func TestUserInfoEndpoint(t *testing.T) {
 				claims:        []byte(userInfoJson),
 			},
 		},
+		{
+			name: "signed jwt userinfo, content-type with charset",
+			server: testServer{
+				contentType: "application/jwt; charset=ISO-8859-1",
+				// generated with jwt.io based on the private/public key pair
+				userInfo: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwicHJvZmlsZSI6IkpvZSBEb2UiLCJlbWFpbCI6ImpvZUBkb2UuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImlzX2FkbWluIjp0cnVlfQ.AP9Y8Md1rjPfuFPTw7hI6kREQe1J0Wb2P5SeVnu_dmAFAyYbG8nbu2Xveb4HOY9wMZbU7UAuSrlvvF_duImlIWei_Ym0ZVrFDATYoMI_MNKwmt4-vM_pm-97zghuPfpXTLYenHgeyPTkHv_SEwhiKzg0Ap7kC3PlAOGeElMO1L1thDZdMd1MqClOEzie00fZwbUGXwkUdDV0_vd173GBACniEQF_9qtgDyxNzh9IMYPNVdRk0bqzBCdQuhTE1AQmWebTrri962uHdWex25KEk_sxOsSW5HIDc0vEF8uBBPUJjaHDPTvwzMh0RuqwT_SqwJvyOHhG0jSz-LYEa5eugQ",
+			},
+			wantUserInfo: UserInfo{
+				Subject:       "1234567890",
+				Profile:       "Joe Doe",
+				Email:         "joe@doe.com",
+				EmailVerified: true,
+				claims:        []byte(userInfoJson),
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Hi.

This PR fixes a case when the userinfo endpoint responds (properly) with `charset` encoding in the `Content-Type` header.
This case wasn't properly handled before and it came up during tests with one of the authorization servers we're using.

