### PR TITLE
oidc: separate NewProvider context and Verifier context

### DIFF
--- a/oidc/oidc_test.go
+++ b/oidc/oidc_test.go
@@ -300,6 +300,19 @@ func TestNewProvider(t *testing.T) {
 	}
 }
 
+func TestCloneContext(t *testing.T) {
+	ctx := context.Background()
+	if _, ok := cloneContext(ctx).Value(oauth2.HTTPClient).(*http.Client); ok {
+		t.Errorf("cloneContext(): expected no *http.Client from empty context")
+	}
+
+	c := &http.Client{}
+	ctx = ClientContext(ctx, c)
+	if got, ok := cloneContext(ctx).Value(oauth2.HTTPClient).(*http.Client); !ok || c != got {
+		t.Errorf("cloneContext(): expected *http.Client from context")
+	}
+}
+
 type testServer struct {
 	contentType string
 	userInfo    string


### PR DESCRIPTION
Because NewProvider needs the RemoteKeySet for UserInfo responses, just
create a new context for the RemoteKeySet. RemoteKeySet should be
garbage collected once it's not used, so it's not clear we need the
cancelation.

Updates #232
Updates #214