### PR TITLE
IDTokenVerifier: fix typo word in Verify function's comment

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -185,7 +185,7 @@ func parseClaim(raw []byte, name string, v interface{}) error {
 	return json.Unmarshal([]byte(val), v)
 }
 
-// Verify parses a raw ID Token, verifies it's been signed by the provider, preforms
+// Verify parses a raw ID Token, verifies it's been signed by the provider, performs
 // any additional checks depending on the Config, and returns the payload.
 //
 // Verify does NOT do nonce validation, which is the callers responsibility.


### PR DESCRIPTION
this fix one word typo of the IDTokenVerifier.Verify function's comment

Fixes #265