### PR TITLE
Change Go Version Used in .travis.yml to v1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - "1.12"
-  - "1.13"
+  - "1.14"
 
 install:
  - go get -v -t github.com/coreos/go-oidc/...


### PR DESCRIPTION
This PR change: use go version v1.14 in .travis.yml to prevent CI keeps failing.

Fixes #267 