### PR TITLE
Don't store provider context in KeySet

### DIFF
--- a/jwks_test.go
+++ b/jwks_test.go
@@ -146,7 +146,7 @@ func testKeyVerify(t *testing.T, good, bad *signingKey, verification ...*signing
 	s := httptest.NewServer(&keyServer{keys: keySet})
 	defer s.Close()
 
-	rks := newRemoteKeySet(ctx, s.URL, nil)
+	rks := newRemoteKeySet(s.URL, nil, nil)
 
 	// Ensure the token verifies.
 	gotPayload, err := rks.verify(ctx, jws)
@@ -206,7 +206,7 @@ func TestCacheControl(t *testing.T) {
 	s := httptest.NewServer(server)
 	defer s.Close()
 
-	rks := newRemoteKeySet(ctx, s.URL, func() time.Time { return now })
+	rks := newRemoteKeySet(s.URL, nil, func() time.Time { return now })
 
 	if _, err := rks.verify(ctx, jws1); err != nil {
 		t.Errorf("failed to verify valid signature: %v", err)

--- a/oidc.go
+++ b/oidc.go
@@ -75,6 +75,7 @@ type Provider struct {
 	rawClaims []byte
 
 	remoteKeySet KeySet
+	client       *http.Client
 }
 
 type cachedKeys struct {
@@ -146,6 +147,9 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 			algs = append(algs, a)
 		}
 	}
+
+	client, _ := ctx.Value(oauth2.HTTPClient).(*http.Client)
+
 	return &Provider{
 		issuer:       p.Issuer,
 		authURL:      p.AuthURL,
@@ -153,7 +157,7 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 		userInfoURL:  p.UserInfoURL,
 		algorithms:   algs,
 		rawClaims:    body,
-		remoteKeySet: NewRemoteKeySet(ctx, p.JWKSURL),
+		remoteKeySet: NewRemoteKeySet(p.JWKSURL, client),
 	}, nil
 }
 

--- a/verify.go
+++ b/verify.go
@@ -103,9 +103,6 @@ type Config struct {
 }
 
 // Verifier returns an IDTokenVerifier that uses the provider's key set to verify JWTs.
-//
-// The returned IDTokenVerifier is tied to the Provider's context and its behavior is
-// undefined once the Provider's context is canceled.
 func (p *Provider) Verifier(config *Config) *IDTokenVerifier {
 	if len(config.SupportedSigningAlgs) == 0 && len(p.algorithms) > 0 {
 		// Make a copy so we don't modify the config values.


### PR DESCRIPTION
Verify is passed its own context; use this one instead. This avoids any
issue with the providers context going stale.

Since it was effectively only used to store a value for oauth2.HTTPClient,
we can extract this in oidc.NewProvider and pass it explicitly to the
KeySet.

This could potentially cause a subtle bug if users depend on this
specifically being accessed from the context, and are assigning new
http.Clients into the same context instead of modifying the client
instance that already exists, since now only the client stored in the
context at the time of NewProvider will be used.

On the other hand, making this change avoids some undefined behavior,
and storing contexts in structs is arguably an anti-pattern.

