### PR TITLE
also run travis tests under 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - "1.14"
+  - "1.15"
 
 install:
  - go get -v -t github.com/coreos/go-oidc/...


### PR DESCRIPTION
Followup from https://github.com/coreos/go-oidc/pull/268