### PR TITLE
Added power support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: go
 go:
   - "1.14"
   - "1.15"
-
+arch:
+  - AMD64
+  - ppc64le
 install:
  - go get -v -t github.com/coreos/go-oidc/...
  - go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.