### PR TITLE
Update jwks doc about cache keys

### DIFF
--- a/oidc/jwks.go
+++ b/oidc/jwks.go
@@ -18,8 +18,8 @@ import (
 // exposed for providers that don't support discovery or to prevent round trips to the
 // discovery URL.
 //
-// The returned KeySet is a long lived verifier that caches keys based on cache-control
-// headers. Reuse a common remote key set instead of creating new ones as needed.
+// The returned KeySet is a long lived verifier that caches keys based on any
+// keys change. Reuse a common remote key set instead of creating new ones as needed.
 func NewRemoteKeySet(ctx context.Context, jwksURL string) *RemoteKeySet {
 	return newRemoteKeySet(ctx, jwksURL, time.Now)
 }


### PR DESCRIPTION
Hi from https://github.com/coreos/go-oidc/commit/8858d8afe4f964bcbc26a582d84dff7548d177c4 the cache-control is not used for checks from key rotation strategy, let me know if you have better suggestion for the text, thanks