### PR TITLE
Add support for MS ADFS

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -75,11 +75,12 @@ func doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
 
 // Provider represents an OpenID Connect server's configuration.
 type Provider struct {
-	issuer      string
-	authURL     string
-	tokenURL    string
-	userInfoURL string
-	algorithms  []string
+	issuer            string
+	accessTokenIssuer string
+	authURL           string
+	tokenURL          string
+	userInfoURL       string
+	algorithms        []string
 
 	// Raw claims returned by the server.
 	rawClaims []byte
@@ -88,12 +89,13 @@ type Provider struct {
 }
 
 type providerJSON struct {
-	Issuer      string   `json:"issuer"`
-	AuthURL     string   `json:"authorization_endpoint"`
-	TokenURL    string   `json:"token_endpoint"`
-	JWKSURL     string   `json:"jwks_uri"`
-	UserInfoURL string   `json:"userinfo_endpoint"`
-	Algorithms  []string `json:"id_token_signing_alg_values_supported"`
+	Issuer            string   `json:"issuer"`
+	AccessTokenIssuer string   `json:"access_token_issuer"`
+	AuthURL           string   `json:"authorization_endpoint"`
+	TokenURL          string   `json:"token_endpoint"`
+	JWKSURL           string   `json:"jwks_uri"`
+	UserInfoURL       string   `json:"userinfo_endpoint"`
+	Algorithms        []string `json:"id_token_signing_alg_values_supported"`
 }
 
 // supportedAlgorithms is a list of algorithms explicitly supported by this
@@ -152,13 +154,14 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 		}
 	}
 	return &Provider{
-		issuer:       p.Issuer,
-		authURL:      p.AuthURL,
-		tokenURL:     p.TokenURL,
-		userInfoURL:  p.UserInfoURL,
-		algorithms:   algs,
-		rawClaims:    body,
-		remoteKeySet: NewRemoteKeySet(cloneContext(ctx), p.JWKSURL),
+		issuer:            p.Issuer,
+		accessTokenIssuer: p.AccessTokenIssuer,
+		authURL:           p.AuthURL,
+		tokenURL:          p.TokenURL,
+		userInfoURL:       p.UserInfoURL,
+		algorithms:        algs,
+		rawClaims:         body,
+		remoteKeySet:      NewRemoteKeySet(cloneContext(ctx), p.JWKSURL),
 	}, nil
 }
 

--- a/oidc/verify.go
+++ b/oidc/verify.go
@@ -254,19 +254,24 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 	// Check issuer.
 	if !v.config.SkipIssuerCheck && t.Issuer != v.issuer {
 		if v.config.AdfsCompatibility {
+			// ADFS appends the string "/services/trust" to the issuer string, breaking the standard.
+			// More details can be found here:
+			// https://github.com/aspnet/Security/issues/1852
 			expectedIssuer := v.issuer + "/services/trust"
 			if t.Issuer != expectedIssuer {
 				return nil, fmt.Errorf("oidc: id token issued by a different provider, expected %q got %q", expectedIssuer, t.Issuer)
 			}
-		} else {
+		} else if v.issuer == issuerGoogleAccounts {
 			// Google sometimes returns "accounts.google.com" as the issuer claim instead of
 			// the required "https://accounts.google.com". Detect this case and allow it only
 			// for Google.
 			//
 			// We will not add hooks to let other providers go off spec like this.
-			if !(v.issuer == issuerGoogleAccounts && t.Issuer == issuerGoogleAccountsNoScheme) {
-				return nil, fmt.Errorf("oidc: id token issued by a different provider, expected %q got %q", v.issuer, t.Issuer)
+			if t.Issuer != issuerGoogleAccountsNoScheme {
+				return nil, fmt.Errorf("oidc: id token issued by a different provider, expected %q got %q", issuerGoogleAccountsNoScheme, t.Issuer)
 			}
+		} else {
+			return nil, fmt.Errorf("oidc: id token issued by a different provider, expected %q got %q", v.issuer, t.Issuer)
 		}
 	}
 

--- a/oidc/verify.go
+++ b/oidc/verify.go
@@ -242,7 +242,7 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 	// Check issuer.
 	if !v.config.SkipIssuerCheck && t.Issuer != v.issuer {
 		if v.config.AdfsCompatibility && len(v.accessTokenIssuer) > 0 {
-			// ADFS might define an access token issuer url which is separate from the issuer url.
+			// ADFS might define an access token issuer url which is distinct from the issuer url.
 			// In this case we should compare the token issuer against the access token issuer.
 			// More details can be found here:
 			// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-oidce/586de7dd-3385-47c7-93a2-935d9e90441c

--- a/oidc/verify.go
+++ b/oidc/verify.go
@@ -98,9 +98,6 @@ type Config struct {
 	// this option.
 	SkipIssuerCheck bool
 
-	// AdfsCompatibility accepts tokens issued by ADFS which are breaking the standard.
-	AdfsCompatibility bool
-
 	// Time function to check Token expiry. Defaults to time.Now
 	Now func() time.Time
 }
@@ -239,24 +236,12 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 
 	// Check issuer.
 	if !v.config.SkipIssuerCheck && t.Issuer != v.issuer {
-		if v.config.AdfsCompatibility {
-			// ADFS appends the string "/services/trust" to the issuer string, breaking the standard.
-			// More details can be found here:
-			// https://github.com/aspnet/Security/issues/1852
-			expectedIssuer := v.issuer + "/services/trust"
-			if t.Issuer != expectedIssuer {
-				return nil, fmt.Errorf("oidc: id token issued by a different provider, expected %q got %q", expectedIssuer, t.Issuer)
-			}
-		} else if v.issuer == issuerGoogleAccounts {
-			// Google sometimes returns "accounts.google.com" as the issuer claim instead of
-			// the required "https://accounts.google.com". Detect this case and allow it only
-			// for Google.
-			//
-			// We will not add hooks to let other providers go off spec like this.
-			if t.Issuer != issuerGoogleAccountsNoScheme {
-				return nil, fmt.Errorf("oidc: id token issued by a different provider, expected %q got %q", issuerGoogleAccountsNoScheme, t.Issuer)
-			}
-		} else {
+		// Google sometimes returns "accounts.google.com" as the issuer claim instead of
+		// the required "https://accounts.google.com". Detect this case and allow it only
+		// for Google.
+		//
+		// We will not add hooks to let other providers go off spec like this.
+		if !(v.issuer == issuerGoogleAccounts && t.Issuer == issuerGoogleAccountsNoScheme) {
 			return nil, fmt.Errorf("oidc: id token issued by a different provider, expected %q got %q", v.issuer, t.Issuer)
 		}
 	}

--- a/oidc/verify_test.go
+++ b/oidc/verify_test.go
@@ -145,6 +145,17 @@ func TestVerify(t *testing.T) {
 			},
 			signKey: newRSAKey(t),
 		},
+		{
+			name:    "adfs token with invalid issuer",
+			idToken: `{"iss":"https://invalid/services/trust"}`,
+			config: Config{
+				SkipClientIDCheck: true,
+				SkipExpiryCheck:   true,
+				AdfsCompatibility: true,
+			},
+			signKey: newRSAKey(t),
+			wantErr: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, test.run)
@@ -476,7 +487,6 @@ func TestDistClaimResolver(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 type resolverTest struct {
@@ -580,6 +590,8 @@ func (v verificationTest) runGetToken(t *testing.T) (*IDToken, error) {
 }
 
 func (v verificationTest) run(t *testing.T) {
+	t.Helper()
+
 	_, err := v.runGetToken(t)
 	if err != nil && !v.wantErr {
 		t.Errorf("%v", err)

--- a/oidc/verify_test.go
+++ b/oidc/verify_test.go
@@ -135,6 +135,18 @@ func TestVerify(t *testing.T) {
 			},
 			signKey: newRSAKey(t),
 		},
+		{
+			name:              "test ADFS with distinct access token issuer",
+			idToken:           `{"iss":"https://bar"}`,
+			issuer:            "https://foo",
+			accessTokenIssuer: "https://bar",
+			config: Config{
+				SkipClientIDCheck: true,
+				SkipExpiryCheck:   true,
+				AdfsCompatibility: true,
+			},
+			signKey: newRSAKey(t),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, test.run)
@@ -534,6 +546,9 @@ type verificationTest struct {
 	// If not provided defaults to "https://foo"
 	issuer string
 
+	// If not provided defaults to ""
+	accessTokenIssuer string
+
 	// JWT payload (just the claims).
 	idToken string
 
@@ -563,7 +578,7 @@ func (v verificationTest) runGetToken(t *testing.T) (*IDToken, error) {
 	} else {
 		ks = &testVerifier{v.verificationKey.jwk()}
 	}
-	verifier := NewVerifier(issuer, "", ks, &v.config)
+	verifier := NewVerifier(issuer, v.accessTokenIssuer, ks, &v.config)
 
 	return verifier.Verify(ctx, token)
 }

--- a/oidc/verify_test.go
+++ b/oidc/verify_test.go
@@ -156,6 +156,16 @@ func TestVerify(t *testing.T) {
 			signKey: newRSAKey(t),
 			wantErr: true,
 		},
+		{
+			name:    "adfs token with proper standard issuer",
+			idToken: `{"iss":"https://foo"}`,
+			config: Config{
+				SkipClientIDCheck: true,
+				SkipExpiryCheck:   true,
+				AdfsCompatibility: true,
+			},
+			signKey: newRSAKey(t),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, test.run)

--- a/oidc/verify_test.go
+++ b/oidc/verify_test.go
@@ -466,7 +466,6 @@ func TestDistClaimResolver(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 type resolverTest struct {
@@ -490,7 +489,7 @@ type resolverTest struct {
 	wantErr bool
 	want    map[string]claimSource
 
-	//this is the access token that the testEndpoint will accept
+	// this is the access token that the testEndpoint will accept
 	accessToken string
 }
 
@@ -517,7 +516,7 @@ func (v resolverTest) testEndpoint(t *testing.T) ([]byte, error) {
 	} else {
 		ks = &testVerifier{v.verificationKey.jwk()}
 	}
-	verifier := NewVerifier(issuer, ks, &v.config)
+	verifier := NewVerifier(issuer, "", ks, &v.config)
 
 	ctx = ClientContext(ctx, s.Client())
 
@@ -564,7 +563,7 @@ func (v verificationTest) runGetToken(t *testing.T) (*IDToken, error) {
 	} else {
 		ks = &testVerifier{v.verificationKey.jwk()}
 	}
-	verifier := NewVerifier(issuer, ks, &v.config)
+	verifier := NewVerifier(issuer, "", ks, &v.config)
 
 	return verifier.Verify(ctx, token)
 }

--- a/oidc/verify_test.go
+++ b/oidc/verify_test.go
@@ -135,6 +135,16 @@ func TestVerify(t *testing.T) {
 			},
 			signKey: newRSAKey(t),
 		},
+		{
+			name:    "adfs token",
+			idToken: `{"iss":"https://foo/services/trust"}`,
+			config: Config{
+				SkipClientIDCheck: true,
+				SkipExpiryCheck:   true,
+				AdfsCompatibility: true,
+			},
+			signKey: newRSAKey(t),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, test.run)

--- a/oidc/verify_test.go
+++ b/oidc/verify_test.go
@@ -135,37 +135,6 @@ func TestVerify(t *testing.T) {
 			},
 			signKey: newRSAKey(t),
 		},
-		{
-			name:    "adfs token",
-			idToken: `{"iss":"https://foo/services/trust"}`,
-			config: Config{
-				SkipClientIDCheck: true,
-				SkipExpiryCheck:   true,
-				AdfsCompatibility: true,
-			},
-			signKey: newRSAKey(t),
-		},
-		{
-			name:    "adfs token with invalid issuer",
-			idToken: `{"iss":"https://invalid/services/trust"}`,
-			config: Config{
-				SkipClientIDCheck: true,
-				SkipExpiryCheck:   true,
-				AdfsCompatibility: true,
-			},
-			signKey: newRSAKey(t),
-			wantErr: true,
-		},
-		{
-			name:    "adfs token with proper standard issuer",
-			idToken: `{"iss":"https://foo"}`,
-			config: Config{
-				SkipClientIDCheck: true,
-				SkipExpiryCheck:   true,
-				AdfsCompatibility: true,
-			},
-			signKey: newRSAKey(t),
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, test.run)
@@ -497,6 +466,7 @@ func TestDistClaimResolver(t *testing.T) {
 			}
 		})
 	}
+
 }
 
 type resolverTest struct {
@@ -600,8 +570,6 @@ func (v verificationTest) runGetToken(t *testing.T) (*IDToken, error) {
 }
 
 func (v verificationTest) run(t *testing.T) {
-	t.Helper()
-
 	_, err := v.runGetToken(t)
 	if err != nil && !v.wantErr {
 		t.Errorf("%v", err)


### PR DESCRIPTION
Unfortunately ADFS is relying on a non-standard attribute in its OIDC implementation, specifically the `access_token_issuer`. Details can be found here:

https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-oidce/586de7dd-3385-47c7-93a2-935d9e90441c

This PR adds support for ADFS if the config flag `AdfsCompatibility` is enabled.