### PR TITLE
Add minor error handling

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -178,6 +178,11 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 			algs = append(algs, a)
 		}
 	}
+	
+	if p.JWSKURL == "" {
+		return nil, fmt.Errorf("oidc: remote keys urls is empty")
+	}
+
 	return &Provider{
 		issuer:       issuerURL,
 		authURL:      p.AuthURL,

--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -179,7 +179,7 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 		}
 	}
 	
-	if p.JWSKURL == "" {
+	if p.JWKSURL == "" {
 		return nil, fmt.Errorf("oidc: remote keys urls is empty")
 	}
 


### PR DESCRIPTION
Not sure that this is strictly necessary here but helps debug a bit: adds an error if an empty `jwks_uri` is provided. Although maybe that's allowed?