### PR TITLE
id token: allow to set claims

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -368,6 +368,16 @@ func (i *IDToken) Claims(v interface{}) error {
 	return json.Unmarshal(i.claims, v)
 }
 
+// WithClaims returns a new IDToken that's a clone of i, but using
+// provided claims. This is only intended for test cases or very
+// specific use cases
+func (i *IDToken) WithClaims(claims []byte) *IDToken {
+	i2 := new(IDToken)
+	*i2 = *i
+	i2.claims = claims
+	return i2
+}
+
 // VerifyAccessToken verifies that the hash of the access token that corresponds to the iD token
 // matches the hash in the id token. It returns an error if the hashes  don't match.
 // It is the caller's responsibility to ensure that the optional access token hash is present for the ID token

--- a/oidc/oidc_test.go
+++ b/oidc/oidc_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
 )
 
@@ -518,4 +519,15 @@ func TestUserInfoEndpoint(t *testing.T) {
 		})
 	}
 
+}
+
+func TestIDTokenWithClaims(t *testing.T) {
+	idToken := IDToken{
+		Issuer: "accounts.google.com",
+		claims: []byte(`{"iss":"accounts.google.com"}`),
+	}
+	idTokenWithClaims := idToken.WithClaims([]byte(`{"iss":"accounts.google.com","aud":"client1"}`))
+	assert.Equal(t, idToken.Issuer, idTokenWithClaims.Issuer)
+	assert.Equal(t, []byte(`{"iss":"accounts.google.com"}`), idToken.claims)
+	assert.Equal(t, []byte(`{"iss":"accounts.google.com","aud":"client1"}`), idTokenWithClaims.claims)
 }


### PR DESCRIPTION
This method is similar to this [one](https://cs.opensource.google/go/x/oauth2/+/d3ed0bb2:token.go;l=86).

I need a way, in my test cases, to return an ID Token from my mock verifier, I currently use this [reflect hack](https://github.com/drakkan/sftpgo/blob/main/httpd/oidc_test.go#L72).