### PR TITLE
feat: export token expired error

### DIFF
--- a/oidc/verify.go
+++ b/oidc/verify.go
@@ -21,6 +21,18 @@ const (
 	issuerGoogleAccountsNoScheme = "accounts.google.com"
 )
 
+// TokenExpiredError indicates that Verify failed because the token was expired. This
+// error does NOT indicate that the token is not also invalid for other reasons. Other
+// checks might have failed if the expiration check had not failed.
+type TokenExpiredError struct {
+	// Expiry is the time when the token expired.
+	Expiry time.Time
+}
+
+func (e *TokenExpiredError) Error() string {
+	return fmt.Sprintf("oidc: token is expired (Token Expiry: %v)", e.Expiry)
+}
+
 // KeySet is a set of publc JSON Web Keys that can be used to validate the signature
 // of JSON web tokens. This is expected to be backed by a remote key set through
 // provider metadata discovery or an in-memory set of keys delivered out-of-band.
@@ -260,7 +272,7 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 		nowTime := now()
 
 		if t.Expiry.Before(nowTime) {
-			return nil, fmt.Errorf("oidc: token is expired (Token Expiry: %v)", t.Expiry)
+			return nil, &TokenExpiredError{Expiry: t.Expiry}
 		}
 
 		// If nbf claim is provided in token, ensure that it is indeed in the past.


### PR DESCRIPTION
Relates to #327 

This allows `errors.Is` checking while preserving the exact same error messages for those who are doing string comparison.

Preserving the exact same strings means some of the error messages (without context) look a little weird. But I think it's a reasonable tradeoff until it's time for another major version bump.

This PR would let me write unit tests in Argo CD without worrying that a change in go-oidc will break my string comparison checks.