### PR TITLE
Update Issuer verification to skip last useless slash

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -211,7 +211,7 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 	if !skipIssuerValidation {
 		issuerURL = issuer
 	}
-	if p.Issuer != issuerURL && !skipIssuerValidation {
+	if strings.TrimSuffix(p.Issuer, "/") != strings.TrimSuffix(issuerURL, "/") && !skipIssuerValidation {
 		return nil, fmt.Errorf("oidc: issuer did not match the issuer returned by provider, expected %q got %q", issuer, p.Issuer)
 	}
 	var algs []string

--- a/oidc/oidc_test.go
+++ b/oidc/oidc_test.go
@@ -129,6 +129,19 @@ func TestNewProvider(t *testing.T) {
 			wantAlgorithms: []string{"RS256"},
 		},
 		{
+			name: "additional_useless_slash",
+			data: `{
+				"issuer": "ISSUER/",
+				"authorization_endpoint": "https://example.com/auth",
+				"token_endpoint": "https://example.com/token",
+				"jwks_uri": "https://example.com/keys",
+				"id_token_signing_alg_values_supported": ["RS256"]
+			}`,
+			wantAuthURL:    "https://example.com/auth",
+			wantTokenURL:   "https://example.com/token",
+			wantAlgorithms: []string{"RS256"},
+		},
+		{
 			name: "additional_algorithms",
 			data: `{
 				"issuer": "ISSUER",


### PR DESCRIPTION
Some OIDC solution provider return the Issuer in openid-configuration with useless slash at the end.
That fix allows to skip the last slash during Issuer compare.