### PR TITLE
oidc: restrict use of context.Background()

### DIFF
--- a/oidc/jwks.go
+++ b/oidc/jwks.go
@@ -60,7 +60,7 @@ func newRemoteKeySet(ctx context.Context, jwksURL string, now func() time.Time) 
 	if now == nil {
 		now = time.Now
 	}
-	return &RemoteKeySet{jwksURL: jwksURL, ctx: cloneContext(ctx), now: now}
+	return &RemoteKeySet{jwksURL: jwksURL, ctx: ctx, now: now}
 }
 
 // RemoteKeySet is a KeySet implementation that validates JSON web tokens against

--- a/oidc/oidc_test.go
+++ b/oidc/oidc_test.go
@@ -326,15 +326,15 @@ func TestNewProvider(t *testing.T) {
 	}
 }
 
-func TestCloneContext(t *testing.T) {
+func TestGetClient(t *testing.T) {
 	ctx := context.Background()
-	if _, ok := cloneContext(ctx).Value(oauth2.HTTPClient).(*http.Client); ok {
+	if c := getClient(ctx); c != nil {
 		t.Errorf("cloneContext(): expected no *http.Client from empty context")
 	}
 
 	c := &http.Client{}
 	ctx = ClientContext(ctx, c)
-	if got, ok := cloneContext(ctx).Value(oauth2.HTTPClient).(*http.Client); !ok || c != got {
+	if got := getClient(ctx); got == nil || c != got {
 		t.Errorf("cloneContext(): expected *http.Client from context")
 	}
 }


### PR DESCRIPTION
This causes NewRemoteKeySet not to detach the context, and adds a method to create a verifier with an explicit context:

```
func (*Provider) VerifierContext(context.Context, *Config) *IDTokenVerifier
```

Fixes https://github.com/coreos/go-oidc/issues/339?