### PR TITLE
Support signed JWKs

### DIFF
--- a/oidc/jwks_test.go
+++ b/oidc/jwks_test.go
@@ -244,9 +244,8 @@ func testSignedKeyVerify(t *testing.T, signKeyGood *signingKey, signKeyBad *sign
 		t.Errorf("incorrectly verified signature")
 	}
 
-	rks = newRemoteKeySet(ctx, s.URL, signKeyBad.pub, nil)
-
 	// Ensure the token does not verify with bad sign
+	rks = newRemoteKeySet(ctx, s.URL, signKeyBad.pub, nil)
 	gotPayload, err = rks.verify(ctx, jws)
 	if !errors.Is(err, jose.ErrCryptoFailure) {
 		t.Fatal(err)

--- a/oidc/jwks_test.go
+++ b/oidc/jwks_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -247,7 +248,7 @@ func testSignedKeyVerify(t *testing.T, signKeyGood *signingKey, signKeyBad *sign
 
 	// Ensure the token does not verify with bad sign
 	gotPayload, err = rks.verify(ctx, jws)
-	if err == nil {
+	if !errors.Is(err, jose.ErrCryptoFailure) {
 		t.Fatal(err)
 	}
 	if len(gotPayload) != 0 {
@@ -345,7 +346,7 @@ func BenchmarkVerify(b *testing.B) {
 	s := httptest.NewServer(server)
 	defer s.Close()
 
-	rks := NewRemoteKeySet(ctx, s.URL, nil)
+	rks := NewRemoteKeySet(ctx, s.URL)
 	verifier := NewVerifier("https://example.com", rks, &Config{
 		ClientID: "test_client_id",
 		Now:      func() time.Time { return now },

--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -124,7 +124,7 @@ func (p *Provider) remoteKeySet() KeySet {
 		if p.client != nil {
 			ctx = ClientContext(ctx, p.client)
 		}
-		p.commonRemoteKeySet = NewRemoteKeySet(ctx, p.jwksURL, p.jwksSigningKey)
+		p.commonRemoteKeySet = NewSignedRemoteKeySet(ctx, p.jwksURL, p.jwksSigningKey)
 	}
 	return p.commonRemoteKeySet
 }

--- a/oidc/verify.go
+++ b/oidc/verify.go
@@ -123,7 +123,7 @@ type Config struct {
 // verify JWTs. As opposed to Verifier, the context is used for all requests to
 // the upstream JWKs endpoint.
 func (p *Provider) VerifierContext(ctx context.Context, config *Config) *IDTokenVerifier {
-	return p.newVerifier(NewRemoteKeySet(ctx, p.jwksURL, p.jwksSigningKey), config)
+	return p.newVerifier(NewSignedRemoteKeySet(ctx, p.jwksURL, p.jwksSigningKey), config)
 }
 
 // Verifier returns an IDTokenVerifier that uses the provider's key set to verify JWTs.

--- a/oidc/verify.go
+++ b/oidc/verify.go
@@ -64,14 +64,13 @@ type IDTokenVerifier struct {
 // This constructor can be used to create a verifier directly using the issuer URL and
 // JSON Web Key Set URL without using discovery:
 //
-//		keySet := oidc.NewRemoteKeySet(ctx, "https://www.googleapis.com/oauth2/v3/certs")
-//		verifier := oidc.NewVerifier("https://accounts.google.com", keySet, config)
+//	keySet := oidc.NewRemoteKeySet(ctx, "https://www.googleapis.com/oauth2/v3/certs")
+//	verifier := oidc.NewVerifier("https://accounts.google.com", keySet, config)
 //
 // Or a static key set (e.g. for testing):
 //
-//		keySet := &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pub1, pub2}}
-//		verifier := oidc.NewVerifier("https://accounts.google.com", keySet, config)
-//
+//	keySet := &oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{pub1, pub2}}
+//	verifier := oidc.NewVerifier("https://accounts.google.com", keySet, config)
 func NewVerifier(issuerURL string, keySet KeySet, config *Config) *IDTokenVerifier {
 	return &IDTokenVerifier{keySet: keySet, config: config, issuer: issuerURL}
 }
@@ -124,7 +123,7 @@ type Config struct {
 // verify JWTs. As opposed to Verifier, the context is used for all requests to
 // the upstream JWKs endpoint.
 func (p *Provider) VerifierContext(ctx context.Context, config *Config) *IDTokenVerifier {
-	return p.newVerifier(NewRemoteKeySet(ctx, p.jwksURL), config)
+	return p.newVerifier(NewRemoteKeySet(ctx, p.jwksURL, p.jwksSigningKey), config)
 }
 
 // Verifier returns an IDTokenVerifier that uses the provider's key set to verify JWTs.
@@ -207,19 +206,18 @@ func resolveDistributedClaim(ctx context.Context, verifier *IDTokenVerifier, src
 //
 // See: https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
 //
-//    oauth2Token, err := oauth2Config.Exchange(ctx, r.URL.Query().Get("code"))
-//    if err != nil {
-//        // handle error
-//    }
+//	oauth2Token, err := oauth2Config.Exchange(ctx, r.URL.Query().Get("code"))
+//	if err != nil {
+//	    // handle error
+//	}
 //
-//    // Extract the ID Token from oauth2 token.
-//    rawIDToken, ok := oauth2Token.Extra("id_token").(string)
-//    if !ok {
-//        // handle error
-//    }
+//	// Extract the ID Token from oauth2 token.
+//	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
+//	if !ok {
+//	    // handle error
+//	}
 //
-//    token, err := verifier.Verify(ctx, rawIDToken)
-//
+//	token, err := verifier.Verify(ctx, rawIDToken)
 func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDToken, error) {
 	// Throw out tokens with invalid claims before trying to verify the token. This lets
 	// us do cheap checks before possibly re-syncing keys.


### PR DESCRIPTION
OpenID Federation specification has signed JWKs, `signed_jwks_uri` in the [metadata](https://openid.net/specs/openid-connect-federation-1_0.html#name-openid-connect-and-oauth2-m).

Some identity providers already support this for added security.

This PR adds support to provide public key which is used to verify signature in the JWT. The signed JWKs are determined by content type "application/jwk-set+jwt". The provider must be configured manually with the call to `NewSignedRemoteKeySet()`. This is because the OpenID discovery document doesn't include `signed_jwks_uri` at the moment but it's only specified in OpenID Federation.