### PR TITLE
oidc: add UserInfoEndpoint returning the discocvered URL

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -275,6 +275,12 @@ func (p *Provider) Endpoint() oauth2.Endpoint {
 	return oauth2.Endpoint{AuthURL: p.authURL, TokenURL: p.tokenURL}
 }
 
+// UserInfoEndpoint returns the OpenID Connect userinfo endpoint for the given
+// provider.
+func (p *Provider) UserInfoEndpoint() string {
+	return p.userInfoURL
+}
+
 // UserInfo represents the OpenID Connect userinfo claims.
 type UserInfo struct {
 	Subject       string `json:"sub"`


### PR DESCRIPTION
This enables users detect if the provider.UserInfo method would fail ahead of time, by checking for the empty string in UserInfoEndpoint.

Fixes #373
Fixes #374