### PR TITLE
limit the size of the logged response to 2048 bytes in error cases

### DIFF
--- a/oidc/jwks.go
+++ b/oidc/jwks.go
@@ -7,7 +7,7 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -230,13 +230,13 @@ func (r *RemoteKeySet) updateKeys() ([]jose.JSONWebKey, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRespBodySize))
 	if err != nil {
 		return nil, fmt.Errorf("unable to read response body: %v", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("oidc: get keys failed: %s %s", resp.Status, body)
+		return nil, fmt.Errorf("oidc: get keys failed: %s %s", resp.Status, body[:getMaxLogSizeForBody(body)])
 	}
 
 	var keySet jose.JSONWebKeySet

--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -216,7 +216,11 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s: %s", resp.Status, body)
+		maxBodySize := len(body)
+		if maxBodySize > 2048 {
+			maxBodySize = 2048
+		}
+		return nil, fmt.Errorf("%s: %s", resp.Status, body[:maxBodySize])
 	}
 
 	var p providerJSON

--- a/oidc/verify.go
+++ b/oidc/verify.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -182,7 +182,7 @@ func resolveDistributedClaim(ctx context.Context, verifier *IDTokenVerifier, src
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRespBodySize))
 	if err != nil {
 		return nil, fmt.Errorf("unable to read response body: %v", err)
 	}


### PR DESCRIPTION
Fixes #306

Maybe we should also limit the size while reading the body itself, currently we have

```
body, err := ioutil.ReadAll(resp.Body)
```

we could do instead

```
body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 262144))
```
