### PR TITLE
oidc: Allows client to read configuration

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -281,6 +281,19 @@ func (p *Provider) UserInfoEndpoint() string {
 	return p.userInfoURL
 }
 
+// Sends back a generated copy of the Provider's configuration, for clients
+// that might need to know this info from an automated Discovery Endpoint.
+func (p *Provider) Config() ProviderConfig {
+	return ProviderConfig{
+		IssuerURL: p.issuer,
+		AuthURL: p.authURL,
+		TokenURL: p.tokenURL,
+		UserInfoURL: p.userInfoURL,
+		JWKSURL: p.jwksURL,
+		Algorithms: p.algorithms,
+	}
+}
+
 // UserInfo represents the OpenID Connect userinfo claims.
 type UserInfo struct {
 	Subject       string `json:"sub"`


### PR DESCRIPTION
This provides a copy of the running configuration to clients after it has been obtained from a Discovery Endpoint.  This is accomplished by adding a Config() method to the oidc.Provider type, which loads a new oidc.ProviderConfig struct with the values the Provider is running with and returns it to the user.