### PR TITLE
oidc: use %w verb for wrapping errors

### DIFF
--- a/oidc/jwks.go
+++ b/oidc/jwks.go
@@ -159,7 +159,7 @@ func (r *RemoteKeySet) verify(ctx context.Context, jws *jose.JSONWebSignature) (
 	// https://openid.net/specs/openid-connect-core-1_0.html#RotateSigKeys
 	keys, err := r.keysFromRemote(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("fetching keys %v", err)
+		return nil, fmt.Errorf("fetching keys %w", err)
 	}
 
 	for _, key := range keys {
@@ -228,7 +228,7 @@ func (r *RemoteKeySet) updateKeys() ([]jose.JSONWebKey, error) {
 
 	resp, err := doRequest(r.ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("oidc: get keys failed %v", err)
+		return nil, fmt.Errorf("oidc: get keys failed %w", err)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
Errors wrapped using %v cannot be unwrapped. This means if there is an underlying error such as `context.Canceled`, a caller cannot reliably discover that error using any method other than string comparison. By swapping to the %w verb, `errors.Is` and `errors.As` become valuable tools for error discovery and behavior differentiation.

While by convention, some of the errors like `fetching keys %v` should probably be changed to `fetching keys: %w` (with the `:` character), this change opts not to do that to help preserve backward compatibility for external error handling that uses string comparison today.