### PR TITLE
Typed errors for the verifier

### DIFF
--- a/oidc/errors.go
+++ b/oidc/errors.go
@@ -1,0 +1,43 @@
+package oidc
+
+import (
+	"fmt"
+	"time"
+)
+
+// TokenExpiredError indicates that Verify failed because the token was expired. This
+// error does NOT indicate that the token is not also invalid for other reasons. Other
+// checks might have failed if the expiration check had not failed.
+type TokenExpiredError struct {
+	// Expiry is the time when the token expired.
+	Expiry time.Time
+}
+
+func (e *TokenExpiredError) Error() string {
+	return fmt.Sprintf("oidc: token is expired (Token Expiry: %v)", e.Expiry)
+}
+
+// InvalidIssuerError indicates that Verify failed because the token was issued
+// by an unexpected issuer. This error does NOT indicate that the token is not
+// also invalid for other reasons. Other checks might have failed if the issuer
+// check had not failed.
+type InvalidIssuerError struct {
+	Expected, Actual string
+}
+
+func (e *InvalidIssuerError) Error() string {
+	return fmt.Sprintf("oidc: id token issued by a different provider, expected %q got %q", e.Expected, e.Actual)
+}
+
+// InvalidAudienceError indicates that Verify failed because the token was
+// intended for a different audience. This error does NOT indicate that the
+// token is not also invalid for other reasons. Other checks might have failed
+// if the audience check had not failed.
+type InvalidAudienceError struct {
+	Expected string
+	Actual   []string
+}
+
+func (e *InvalidAudienceError) Error() string {
+	return fmt.Sprintf("oidc: expected audience %q got %q", e.Expected, e.Actual)
+}

--- a/oidc/verify_test.go
+++ b/oidc/verify_test.go
@@ -631,7 +631,7 @@ func (v verificationTest) runGetToken(t *testing.T) (*IDToken, error) {
 func (v verificationTest) run(t *testing.T) {
 	_, err := v.runGetToken(t)
 	if msg := v.errFunc(err); msg != "" {
-		t.Errorf("%v", msg)
+		t.Error(msg)
 	}
 }
 
@@ -654,7 +654,7 @@ func expectSuccess(err error) string {
 func expectErrorType[T error](err error) string {
 	var errT T
 	if !errors.As(err, &errT) {
-		return fmt.Sprintf("expected %T but got %T", errT, err)
+		return fmt.Sprintf("expected error type %T but got %T", errT, err)
 	}
 
 	return ""


### PR DESCRIPTION
This Pull Request adds error types to some of the errors returned but the `IDTokenVerifier.Verify` method.
The reasoning here is that in some cases these errors can return more information than you'd like to present to the caller. If you need to perform some filtering on your end (eg. disclose the presented but not the expected audience), it would be more convenient to do it based on well-defined types.

I added tests to ensure that the presented error messages are backwards compatible, and that returned errors are of the correct type. For that I extended the existing testing framework to allow more introspection on returned errors.

I hope it's OK that I used generics here. Looking at the `go.mod` file it should be supported out of the box but if you prefer me to rewrite it without generics, that's not a biggie either.

Thanks!