### PR TITLE
feat: export unexpected audience error

### DIFF
--- a/oidc/verify_test.go
+++ b/oidc/verify_test.go
@@ -175,8 +175,8 @@ func TestVerifyAudience(t *testing.T) {
 				ClientID:        "client1",
 				SkipExpiryCheck: true,
 			},
-			signKey: newRSAKey(t),
-			wantErr: true,
+			signKey:    newRSAKey(t),
+			wantErrAud: true,
 		},
 		{
 			name:    "multiple audiences, one matches",
@@ -573,6 +573,7 @@ type verificationTest struct {
 	config        Config
 	wantErr       bool
 	wantErrExpiry bool
+	wantErrAud    bool
 }
 
 func (v verificationTest) runGetToken(t *testing.T) (*IDToken, error) {
@@ -605,16 +606,22 @@ func (v verificationTest) runGetToken(t *testing.T) (*IDToken, error) {
 
 func (v verificationTest) run(t *testing.T) {
 	_, err := v.runGetToken(t)
-	if err != nil && !v.wantErr && !v.wantErrExpiry {
+	if err != nil && !v.wantErr && !v.wantErrExpiry && !v.wantErrAud {
 		t.Errorf("%v", err)
 	}
-	if err == nil && (v.wantErr || v.wantErrExpiry) {
+	if err == nil && (v.wantErr || v.wantErrExpiry || v.wantErrAud) {
 		t.Errorf("expected error")
 	}
 	if v.wantErrExpiry {
 		var errExp *TokenExpiredError
 		if !errors.As(err, &errExp) {
 			t.Errorf("expected *TokenExpiryError but got %q", err)
+		}
+	}
+	if v.wantErrAud {
+		var errAud *UnexpectedAudienceError
+		if !errors.As(err, &errAud) {
+			t.Errorf("expected *AudienceError but got %q", err)
 		}
 	}
 }


### PR DESCRIPTION
Argo CD loops over an OIDC provider's configured allowed audiences, attempting to verify each one. If verification fails, we try more providers. https://github.com/argoproj/argo-cd/blob/0b35e2f1fe27f395e6106a7466d58911c4f7ec9c/util/oidc/provider.go#L108-L120

Since we don't know exactly _why_ token verification fails, we have no way to know whether we should short-circuit the loop. After all, if the token is invalid for some reason besides a disallowed audience, it's a waste of time trying to validate against other audiences.

Knowing that the verification failed due to an invalid audience would allow us to do two things:
1) short-circuit the loop if we encounter an error unrelated to audiences
2) log only the relevant error message rather than continuing the loop and logging an unrelated error about unmatching audiences

Yucky workaround I'm using for now: https://github.com/argoproj/argo-cd/pull/16625