### PR TITLE
Add access to Provider client from the provider

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -289,6 +289,12 @@ func (p *Provider) UserInfoEndpoint() string {
 	return p.userInfoURL
 }
 
+// ClientContext returns a new context that carries the given HTTP client with
+// provider.
+func (p *Provider) ClientContext(ctx context.Context) context.Context {
+	return ClientContext(ctx, p.client)
+}
+
 // UserInfo represents the OpenID Connect userinfo claims.
 type UserInfo struct {
 	Subject       string `json:"sub"`

--- a/oidc/oidc_test.go
+++ b/oidc/oidc_test.go
@@ -338,6 +338,35 @@ func TestNewProvider(t *testing.T) {
 	}
 }
 
+func TestProviderClientContext(t *testing.T) {
+	testServer := testServer{}
+
+	serverURL := testServer.run(t)
+
+	ctx := context.Background()
+
+	provider, err := NewProvider(ctx, serverURL)
+	if err != nil {
+		t.Errorf("Failed to initialize provider for test %v", err)
+	}
+
+	if c := getClient(provider.ClientContext(context.Background())); c != nil {
+		t.Errorf("cloneContext(): expected no *http.Client from empty context")
+	}
+
+	client := &http.Client{}
+	provider, err = NewProvider(ClientContext(ctx, client), serverURL)
+
+	if err != nil {
+		t.Errorf("Failed to initialize provider with *httpClient for test %v", err)
+	}
+
+	ctx = provider.ClientContext(context.Background())
+	if got := getClient(ctx); got == nil || client != got {
+		t.Errorf("cloneContext(): expected *http.Client from context")
+	}
+}
+
 func TestGetClient(t *testing.T) {
 	ctx := context.Background()
 	if c := getClient(ctx); c != nil {


### PR DESCRIPTION
This is helpful when we want to call Exchange with the client we provided to the Provider