### PR TITLE
oidc: ignore cancellation of remote key set context

### DIFF
--- a/oidc/verify.go
+++ b/oidc/verify.go
@@ -120,8 +120,8 @@ type Config struct {
 }
 
 // VerifierContext returns an IDTokenVerifier that uses the provider's key set to
-// verify JWTs. As opposed to Verifier, the context is used for all requests to
-// the upstream JWKs endpoint.
+// verify JWTs. As opposed to Verifier, the context is used to configure requests
+// to the upstream JWKs endpoint. The provided context's cancellation is ignored.
 func (p *Provider) VerifierContext(ctx context.Context, config *Config) *IDTokenVerifier {
 	return p.newVerifier(NewRemoteKeySet(ctx, p.jwksURL), config)
 }


### PR DESCRIPTION
This has largely caused confusion. Detach the context from its parent and just use as a bag-of-values for configuration.

Fixes #428