### PR TITLE
fix: wrap error messages in fmt.Errorf

### DIFF
--- a/oidc/jwks.go
+++ b/oidc/jwks.go
@@ -29,7 +29,7 @@ func (s *StaticKeySet) VerifySignature(ctx context.Context, jwt string) ([]byte,
 	// any algorithm.
 	jws, err := jose.ParseSigned(jwt, allAlgs)
 	if err != nil {
-		return nil, fmt.Errorf("parsing jwt: %v", err)
+		return nil, fmt.Errorf("parsing jwt: %w", err)
 	}
 	for _, pub := range s.PublicKeys {
 		switch pub.(type) {
@@ -149,7 +149,7 @@ func (r *RemoteKeySet) VerifySignature(ctx context.Context, jwt string) ([]byte,
 		var err error
 		jws, err = jose.ParseSigned(jwt, allAlgs)
 		if err != nil {
-			return nil, fmt.Errorf("oidc: malformed jwt: %v", err)
+			return nil, fmt.Errorf("oidc: malformed jwt: %w", err)
 		}
 	}
 	return r.verify(ctx, jws)
@@ -242,7 +242,7 @@ func (r *RemoteKeySet) keysFromRemote(ctx context.Context) ([]jose.JSONWebKey, e
 func (r *RemoteKeySet) updateKeys() ([]jose.JSONWebKey, error) {
 	req, err := http.NewRequest("GET", r.jwksURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("oidc: can't create request: %v", err)
+		return nil, fmt.Errorf("oidc: can't create request: %w", err)
 	}
 
 	resp, err := doRequest(r.ctx, req)
@@ -253,7 +253,7 @@ func (r *RemoteKeySet) updateKeys() ([]jose.JSONWebKey, error) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read response body: %v", err)
+		return nil, fmt.Errorf("unable to read response body: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -263,7 +263,7 @@ func (r *RemoteKeySet) updateKeys() ([]jose.JSONWebKey, error) {
 	var keySet jose.JSONWebKeySet
 	err = unmarshalResp(resp, body, &keySet)
 	if err != nil {
-		return nil, fmt.Errorf("oidc: failed to decode keys: %v %s", err, body)
+		return nil, fmt.Errorf("oidc: failed to decode keys: %w %s", err, body)
 	}
 	return keySet.Keys, nil
 }

--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -219,7 +219,7 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read response body: %v", err)
+		return nil, fmt.Errorf("unable to read response body: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -229,7 +229,7 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 	var p providerJSON
 	err = unmarshalResp(resp, body, &p)
 	if err != nil {
-		return nil, fmt.Errorf("oidc: failed to decode provider discovery object: %v", err)
+		return nil, fmt.Errorf("oidc: failed to decode provider discovery object: %w", err)
 	}
 
 	issuerURL, skipIssuerValidation := ctx.Value(issuerURLKey).(string)
@@ -325,12 +325,12 @@ func (p *Provider) UserInfo(ctx context.Context, tokenSource oauth2.TokenSource)
 
 	req, err := http.NewRequest("GET", p.userInfoURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("oidc: create GET request: %v", err)
+		return nil, fmt.Errorf("oidc: create GET request: %w", err)
 	}
 
 	token, err := tokenSource.Token()
 	if err != nil {
-		return nil, fmt.Errorf("oidc: get access token: %v", err)
+		return nil, fmt.Errorf("oidc: get access token: %w", err)
 	}
 	token.SetAuthHeader(req)
 
@@ -352,14 +352,14 @@ func (p *Provider) UserInfo(ctx context.Context, tokenSource oauth2.TokenSource)
 	if parseErr == nil && mediaType == "application/jwt" {
 		payload, err := p.remoteKeySet().VerifySignature(ctx, string(body))
 		if err != nil {
-			return nil, fmt.Errorf("oidc: invalid userinfo jwt signature %v", err)
+			return nil, fmt.Errorf("oidc: invalid userinfo jwt signature %w", err)
 		}
 		body = payload
 	}
 
 	var userInfo userInfoRaw
 	if err := json.Unmarshal(body, &userInfo); err != nil {
-		return nil, fmt.Errorf("oidc: failed to decode userinfo: %v", err)
+		return nil, fmt.Errorf("oidc: failed to decode userinfo: %w", err)
 	}
 	return &UserInfo{
 		Subject:       userInfo.Subject,
@@ -548,7 +548,7 @@ func unmarshalResp(r *http.Response, body []byte, v interface{}) error {
 	ct := r.Header.Get("Content-Type")
 	mediaType, _, parseErr := mime.ParseMediaType(ct)
 	if parseErr == nil && mediaType == "application/json" {
-		return fmt.Errorf("got Content-Type = application/json, but could not unmarshal as JSON: %v", err)
+		return fmt.Errorf("got Content-Type = application/json, but could not unmarshal as JSON: %w", err)
 	}
-	return fmt.Errorf("expected Content-Type = application/json, got %q: %v", ct, err)
+	return fmt.Errorf("expected Content-Type = application/json, got %q: %w", ct, err)
 }

--- a/oidc/verify.go
+++ b/oidc/verify.go
@@ -152,7 +152,7 @@ func parseJWT(p string) ([]byte, error) {
 	}
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return nil, fmt.Errorf("oidc: malformed jwt payload: %v", err)
+		return nil, fmt.Errorf("oidc: malformed jwt payload: %w", err)
 	}
 	return payload, nil
 }
@@ -170,7 +170,7 @@ func contains(sli []string, ele string) bool {
 func resolveDistributedClaim(ctx context.Context, verifier *IDTokenVerifier, src claimSource) ([]byte, error) {
 	req, err := http.NewRequest("GET", src.Endpoint, nil)
 	if err != nil {
-		return nil, fmt.Errorf("malformed request: %v", err)
+		return nil, fmt.Errorf("malformed request: %w", err)
 	}
 	if src.AccessToken != "" {
 		req.Header.Set("Authorization", "Bearer "+src.AccessToken)
@@ -178,13 +178,13 @@ func resolveDistributedClaim(ctx context.Context, verifier *IDTokenVerifier, src
 
 	resp, err := doRequest(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("oidc: Request to endpoint failed: %v", err)
+		return nil, fmt.Errorf("oidc: Request to endpoint failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read response body: %v", err)
+		return nil, fmt.Errorf("unable to read response body: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -193,7 +193,7 @@ func resolveDistributedClaim(ctx context.Context, verifier *IDTokenVerifier, src
 
 	token, err := verifier.Verify(ctx, string(body))
 	if err != nil {
-		return nil, fmt.Errorf("malformed response body: %v", err)
+		return nil, fmt.Errorf("malformed response body: %w", err)
 	}
 
 	return token.claims, nil
@@ -223,11 +223,11 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 	// us do cheap checks before possibly re-syncing keys.
 	payload, err := parseJWT(rawIDToken)
 	if err != nil {
-		return nil, fmt.Errorf("oidc: malformed jwt: %v", err)
+		return nil, fmt.Errorf("oidc: malformed jwt: %w", err)
 	}
 	var token idToken
 	if err := json.Unmarshal(payload, &token); err != nil {
-		return nil, fmt.Errorf("oidc: failed to unmarshal claims: %v", err)
+		return nil, fmt.Errorf("oidc: failed to unmarshal claims: %w", err)
 	}
 
 	distributedClaims := make(map[string]claimSource)
@@ -321,7 +321,7 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 	}
 	jws, err := jose.ParseSigned(rawIDToken, supportedSigAlgs)
 	if err != nil {
-		return nil, fmt.Errorf("oidc: malformed jwt: %v", err)
+		return nil, fmt.Errorf("oidc: malformed jwt: %w", err)
 	}
 
 	switch len(jws.Signatures) {
@@ -337,7 +337,7 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 	ctx = context.WithValue(ctx, parsedJWTKey, jws)
 	gotPayload, err := v.keySet.VerifySignature(ctx, rawIDToken)
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify signature: %v", err)
+		return nil, fmt.Errorf("failed to verify signature: %w", err)
 	}
 
 	// Ensure that the payload returned by the square actually matches the payload parsed earlier.


### PR DESCRIPTION
use %w instead of %v when nesting error messages so they can be properly unwrapped by upstream callers.

I've run into a problem where I'm unable to use errors.Is() in my tooling to help properly respond to errors coming out of oidc. The primary use case is checking for context.Canceled, but I'm sure there are others.

Note: I believe %w was introduced in Go version 1.13, so this change isn't friendly to users who use a 5 year old Go version but keep their packages up to date. In any case, it's possible this package already requires a higher Go version than that.