### PR TITLE
Switch to maintained go-jose library

### DIFF
--- a/jwks.go
+++ b/jwks.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/pquerna/cachecontrol"
-	jose "gopkg.in/square/go-jose.v2"
+	jose "gopkg.in/go-jose/go-jose.v2"
 )
 
 // keysExpiryDelta is the allowed clock skew between a client and the OpenID Connect

--- a/jwks_test.go
+++ b/jwks_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	jose "gopkg.in/square/go-jose.v2"
+	jose "gopkg.in/go-jose/go-jose.v2"
 )
 
 type keyServer struct {

--- a/oidc.go
+++ b/oidc.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
-	jose "gopkg.in/square/go-jose.v2"
+	jose "gopkg.in/go-jose/go-jose.v2"
 )
 
 const (

--- a/verify.go
+++ b/verify.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
-	jose "gopkg.in/square/go-jose.v2"
+	jose "gopkg.in/go-jose/go-jose.v2"
 )
 
 const (

--- a/verify_test.go
+++ b/verify_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	jose "gopkg.in/square/go-jose.v2"
+	jose "gopkg.in/go-jose/go-jose.v2"
 )
 
 type testVerifier struct {


### PR DESCRIPTION
This allows consumers of the v2 stream to pick up the fix for https://pkg.go.dev/vuln/GO-2024-2631

Switching to v3 changes token generation (due to changes in go-jose) in ways that make it difficult to update without visible behavior changes. Without this, Kubernetes may have to fork the v2 branch of this dependency to update to go-jose. cc @dims for visibility (xref https://github.com/kubernetes/kubernetes/pull/129732#issuecomment-2604924444)

The TMP commits would be dropped and are only there to demonstrate the effective diff in the dependency.

After review, the TMP commits would be dropped and this could be merged and tagged as v2.3.0, etc

* The `Switch to maintained gopkg.in/go-jose/go-jose.v2 library` commit is the only change intended to be merged (only switches import paths for the go-jose library)
* The `TMP: revendor to show effective dependency diff` commit shows the actual dependency change