### PR TITLE
fix: added close for test http servers

### DIFF
--- a/oidc/oidc_test.go
+++ b/oidc/oidc_test.go
@@ -783,8 +783,8 @@ func TestCanceledContext(t *testing.T) {
 		},
 	}
 	srv := httptest.NewServer(ts)
-	ts.baseURL = srv.URL
 	defer srv.Close()
+	ts.baseURL = srv.URL
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/oidc/oidc_test.go
+++ b/oidc/oidc_test.go
@@ -701,6 +701,7 @@ func TestVerifierAlg(t *testing.T) {
 		},
 	}
 	srv := httptest.NewServer(ts)
+	defer srv.Close()
 	ts.baseURL = srv.URL
 
 	ctx := context.Background()
@@ -783,6 +784,7 @@ func TestCanceledContext(t *testing.T) {
 	}
 	srv := httptest.NewServer(ts)
 	ts.baseURL = srv.URL
+	defer srv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
The httptest.NewServer function starts a background goroutine to serve HTTP requests. Without explicitly closing the server, this goroutine can continue running even after the test completes, leading to resource leaks.
This change adds a defer srv.Close() call immediately after server creation.