### PR TITLE
fix confusing error message

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -162,7 +162,7 @@ var supportedAlgorithms = map[string]bool{
 // parsing.
 //
 //	// Directly fetch the metadata document.
-// 	resp, err := http.Get("https://login.example.com/custom-metadata-path")
+//	resp, err := http.Get("https://login.example.com/custom-metadata-path")
 //	if err != nil {
 //		// ...
 //	}
@@ -267,7 +267,7 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 		issuerURL = issuer
 	}
 	if p.Issuer != issuerURL && !skipIssuerValidation {
-		return nil, fmt.Errorf("oidc: issuer did not match the issuer returned by provider, expected %q got %q", issuer, p.Issuer)
+		return nil, fmt.Errorf("oidc: issuer did not match the issuer returned by provider, expected %q got %q", p.Issuer, issuer)
 	}
 	var algs []string
 	for _, a := range p.Algorithms {


### PR DESCRIPTION
When I try to connect to Oauth provider with wrong url I got wrong error message. In example I use localhost:4444 instead of 127.0.0.1. 

Error message:
`error="failed to create OAuth service: failed to create OIDC provider: oidc: issuer did not match the issuer returned by provider, expected \"http://localhost:4444\" got \"http://127.0.0.1:4444\""`

But should be:
`error="failed to create OAuth service: failed to create OIDC provider: oidc: issuer did not match the issuer returned by provider, expected \"http://127.0.0.1:4444\" got \"http://localhost:4444\""`

When i change host to http://127.0.0.1:4444, everything works correctly and got no errors
 