### PR TITLE
feat: add typed error for issuer mismatch

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -40,6 +40,16 @@ var (
 	errInvalidAtHash = errors.New("access token hash does not match value in ID token")
 )
 
+// IssuerMismatchError is returned when the issuer does not match the expected value.
+type IssuerMismatchError struct {
+	Expected string
+	Actual   string
+}
+
+func (e *IssuerMismatchError) Error() string {
+	return fmt.Sprintf("oidc: issuer did not match the issuer returned by provider, expected %q got %q", e.Expected, e.Actual)
+}
+
 type contextKey int
 
 var issuerURLKey contextKey
@@ -162,7 +172,7 @@ var supportedAlgorithms = map[string]bool{
 // parsing.
 //
 //	// Directly fetch the metadata document.
-// 	resp, err := http.Get("https://login.example.com/custom-metadata-path")
+//	resp, err := http.Get("https://login.example.com/custom-metadata-path")
 //	if err != nil {
 //		// ...
 //	}
@@ -267,7 +277,7 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 		issuerURL = issuer
 	}
 	if p.Issuer != issuerURL && !skipIssuerValidation {
-		return nil, fmt.Errorf("oidc: issuer did not match the issuer returned by provider, expected %q got %q", issuer, p.Issuer)
+		return nil, &IssuerMismatchError{Expected: issuer, Actual: p.Issuer}
 	}
 	var algs []string
 	for _, a := range p.Algorithms {

--- a/oidc/oidc_test.go
+++ b/oidc/oidc_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -116,17 +117,18 @@ func TestAccessTokenVerification(t *testing.T) {
 
 func TestNewProvider(t *testing.T) {
 	tests := []struct {
-		name              string
-		data              string
-		issuerURLOverride string
-		trailingSlash     bool
-		wantAuthURL       string
-		wantTokenURL      string
-		wantDeviceAuthURL string
-		wantUserInfoURL   string
-		wantIssuerURL     string
-		wantAlgorithms    []string
-		wantErr           bool
+		name                  string
+		data                  string
+		issuerURLOverride     string
+		trailingSlash         bool
+		wantAuthURL           string
+		wantTokenURL          string
+		wantDeviceAuthURL     string
+		wantUserInfoURL       string
+		wantIssuerURL         string
+		wantAlgorithms        []string
+		wantErr               bool
+		wantErrIssuerMismatch bool
 	}{
 		{
 			name: "basic_case",
@@ -306,13 +308,19 @@ func TestNewProvider(t *testing.T) {
 
 			p, err := NewProvider(ctx, issuer)
 			if err != nil {
-				if !test.wantErr {
+				if !test.wantErr && !test.wantErrIssuerMismatch {
 					t.Errorf("NewProvider() failed: %v", err)
 				}
 				return
 			}
-			if test.wantErr {
+			if test.wantErr || test.wantErrIssuerMismatch {
 				t.Fatalf("NewProvider(): expected error")
+			}
+			if test.wantErrIssuerMismatch {
+				var errExp *IssuerMismatchError
+				if !errors.As(err, &errExp) {
+					t.Errorf("expected *IssuerMismatchError but got %q", err)
+				}
 			}
 
 			if test.wantIssuerURL != "" && p.issuer != test.wantIssuerURL {


### PR DESCRIPTION
Similar to https://github.com/coreos/go-oidc/pull/342. Allows programs to better distinguish and act on issuer mismatch errors. 

When working with the OIDC client, I want to check for different `oidc.NewProvider` failures for more intelligent error handling and determining response codes. For issuer mismatch errors, I currently need to rely on string matching to differentiate these from other cases, but it would be preferable to have a typed error for better comparison checks and more easily access the expected and actual issuer values. 

