### PR TITLE
oidc: verify the ID Token's signature before processing claims

### DIFF
--- a/oidc/jwks_test.go
+++ b/oidc/jwks_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -151,11 +152,8 @@ func TestKeyVerifyContextCanceled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ch := make(chan struct{})
-	defer close(ch)
-
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		<-ch
+		io.WriteString(w, "{}")
 	}))
 	defer s.Close()
 

--- a/oidc/verify_test.go
+++ b/oidc/verify_test.go
@@ -580,9 +580,14 @@ func (v verificationTest) runGetToken(t *testing.T) (*IDToken, error) {
 	if v.signKey != nil {
 		token = v.signKey.sign(t, []byte(v.idToken))
 	} else {
-		token = base64.RawURLEncoding.EncodeToString([]byte(`{alg: "none"}`))
+		// "none" still uses a second "." character, but "...MUST use the empty octet
+		// sequence as its JWS Signature value."
+		//
+		// https://datatracker.ietf.org/doc/html/rfc7518#section-3.6
+		token = base64.RawURLEncoding.EncodeToString([]byte(`{"alg": "none"}`))
 		token += "."
 		token += base64.RawURLEncoding.EncodeToString([]byte(v.idToken))
+		token += "."
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This change updates the verification logic of this library to first validate the ID Token instead of parsing claims. This hopefully makes it harder for a malicious client to provide an invalid token for validation that's crafted to cause this package to over-allocate memory. See the associated bug and CVE-2025-27144.

Fixes https://github.com/coreos/go-oidc/pull/463