### PR TITLE
oidc: verify signature before parsing token

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.22', '1.23']
+        go: ['1.23', '1.24']
     name: Linux Go ${{ matrix.go }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This change updates the verification logic of this library to always verify the signature of the token before validating the payload. See associated issue.

https://github.com/coreos/go-oidc/pull/464