### PR TITLE
refactor: Remove unused time injection from RemoteKeySet

### DIFF
--- a/oidc/jwks.go
+++ b/oidc/jwks.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"sync"
-	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
 )
@@ -57,16 +56,12 @@ func (s *StaticKeySet) VerifySignature(ctx context.Context, jwt string) ([]byte,
 // The returned KeySet is a long lived verifier that caches keys based on any
 // keys change. Reuse a common remote key set instead of creating new ones as needed.
 func NewRemoteKeySet(ctx context.Context, jwksURL string) *RemoteKeySet {
-	return newRemoteKeySet(ctx, jwksURL, time.Now)
+	return newRemoteKeySet(ctx, jwksURL)
 }
 
-func newRemoteKeySet(ctx context.Context, jwksURL string, now func() time.Time) *RemoteKeySet {
-	if now == nil {
-		now = time.Now
-	}
+func newRemoteKeySet(ctx context.Context, jwksURL string) *RemoteKeySet {
 	return &RemoteKeySet{
 		jwksURL: jwksURL,
-		now:     now,
 		// For historical reasons, this package uses contexts for configuration, not just
 		// cancellation. In hindsight, this was a bad idea.
 		//
@@ -81,7 +76,6 @@ func newRemoteKeySet(ctx context.Context, jwksURL string, now func() time.Time) 
 // a jwks_uri endpoint.
 type RemoteKeySet struct {
 	jwksURL string
-	now     func() time.Time
 
 	// Used for configuration. Cancelation is ignored.
 	ctx context.Context

--- a/oidc/jwks_test.go
+++ b/oidc/jwks_test.go
@@ -157,7 +157,7 @@ func TestKeyVerifyContextCanceled(t *testing.T) {
 	}))
 	defer s.Close()
 
-	rks := newRemoteKeySet(ctx, s.URL, nil)
+	rks := newRemoteKeySet(ctx, s.URL)
 
 	cancel()
 
@@ -195,7 +195,7 @@ func testKeyVerify(t *testing.T, good, bad *signingKey, verification ...*signing
 	s := httptest.NewServer(&keyServer{keys: keySet})
 	defer s.Close()
 
-	rks := newRemoteKeySet(ctx, s.URL, nil)
+	rks := newRemoteKeySet(ctx, s.URL)
 
 	// Ensure the token verifies.
 	gotPayload, err := rks.verify(ctx, jws)
@@ -242,7 +242,6 @@ func TestRotation(t *testing.T) {
 	}
 
 	cacheForSeconds := 1200
-	now := time.Now()
 
 	server := &keyServer{
 		keys: jose.JSONWebKeySet{
@@ -255,7 +254,7 @@ func TestRotation(t *testing.T) {
 	s := httptest.NewServer(server)
 	defer s.Close()
 
-	rks := newRemoteKeySet(ctx, s.URL, func() time.Time { return now })
+	rks := newRemoteKeySet(ctx, s.URL)
 
 	if _, err := rks.verify(ctx, jws1); err != nil {
 		t.Errorf("failed to verify valid signature: %v", err)


### PR DESCRIPTION
Remove the time injection parameter and now function field from RemoteKeySet as they were not being used in the codebase. This simplifies the constructor signature and reduces unnecessary complexity in the JWKS key set implementation. The time package import was also removed as it's no longer needed.