### PR TITLE
Fix issuer validation error message order

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -267,7 +267,7 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 		issuerURL = issuer
 	}
 	if p.Issuer != issuerURL && !skipIssuerValidation {
-		return nil, fmt.Errorf("oidc: issuer did not match the issuer returned by provider, expected %q got %q", issuer, p.Issuer)
+		return nil, fmt.Errorf("oidc: issuer did not match the issuer returned by provider, expected %q got %q", p.Issuer, issuer)
 	}
 	var algs []string
 	for _, a := range p.Algorithms {


### PR DESCRIPTION
This pull request makes a small correction to an error message in the `NewProvider` function in `oidc/oidc.go`. The order of the "expected" and "got" values in the error message was swapped to accurately reflect the actual and expected issuer values.