### PR TITLE
oidc: optional azp (authorized party) validation

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -501,16 +501,17 @@ func (i *IDToken) VerifyAccessToken(accessToken string) error {
 }
 
 type idToken struct {
-	Issuer       string                 `json:"iss"`
-	Subject      string                 `json:"sub"`
-	Audience     audience               `json:"aud"`
-	Expiry       jsonTime               `json:"exp"`
-	IssuedAt     jsonTime               `json:"iat"`
-	NotBefore    *jsonTime              `json:"nbf"`
-	Nonce        string                 `json:"nonce"`
-	AtHash       string                 `json:"at_hash"`
-	ClaimNames   map[string]string      `json:"_claim_names"`
-	ClaimSources map[string]claimSource `json:"_claim_sources"`
+	Issuer          string                 `json:"iss"`
+	Subject         string                 `json:"sub"`
+	Audience        audience               `json:"aud"`
+	AuthorizedParty string                 `json:"azp"`
+	Expiry          jsonTime               `json:"exp"`
+	IssuedAt        jsonTime               `json:"iat"`
+	NotBefore       *jsonTime              `json:"nbf"`
+	Nonce           string                 `json:"nonce"`
+	AtHash          string                 `json:"at_hash"`
+	ClaimNames      map[string]string      `json:"_claim_names"`
+	ClaimSources    map[string]claimSource `json:"_claim_sources"`
 }
 
 type claimSource struct {

--- a/oidc/verify.go
+++ b/oidc/verify.go
@@ -100,6 +100,17 @@ type Config struct {
 	// this option.
 	SkipIssuerCheck bool
 
+	// VerifyAuthorizedParty enables validation of the "azp" (authorized party) claim
+	// against the configured ClientID.
+	//
+	// When enabled:
+	//   - if "aud" contains multiple values, "azp" must be present and equal to ClientID
+	//   - if "azp" is present, it must be equal to ClientID
+	//
+	// This is disabled by default because IDTokenVerifier can be used by parties other
+	// than the client that initiated the OpenID Connect flow.
+	VerifyAuthorizedParty bool
+
 	// Time function to check Token expiry. Defaults to time.Now
 	Now func() time.Time
 
@@ -300,6 +311,20 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 			}
 		} else {
 			return nil, fmt.Errorf("oidc: invalid configuration, clientID must be provided or SkipClientIDCheck must be set")
+		}
+	}
+
+	if v.config.VerifyAuthorizedParty {
+		if v.config.ClientID == "" {
+			return nil, fmt.Errorf("oidc: invalid configuration, clientID must be provided when VerifyAuthorizedParty is set")
+		}
+
+		if len(t.Audience) > 1 && token.AuthorizedParty == "" {
+			return nil, fmt.Errorf("oidc: expected authorized party (azp) claim when audience contains multiple values")
+		}
+
+		if token.AuthorizedParty != "" && token.AuthorizedParty != v.config.ClientID {
+			return nil, fmt.Errorf("oidc: expected authorized party (azp) %q got %q", v.config.ClientID, token.AuthorizedParty)
 		}
 	}
 

--- a/oidc/verify_test.go
+++ b/oidc/verify_test.go
@@ -193,6 +193,67 @@ func TestVerifyAudience(t *testing.T) {
 	}
 }
 
+func TestVerifyAuthorizedParty(t *testing.T) {
+	tests := []verificationTest{
+		{
+			name:    "multi audience requires azp when enabled",
+			idToken: `{"iss":"https://foo","aud":["client1","client2"]}`,
+			config: Config{
+				ClientID:              "client2",
+				SkipExpiryCheck:       true,
+				VerifyAuthorizedParty: true,
+			},
+			signKey: newRSAKey(t),
+			wantErr: true,
+		},
+		{
+			name:    "multi audience azp mismatch rejected when enabled",
+			idToken: `{"iss":"https://foo","aud":["client1","client2"],"azp":"client1"}`,
+			config: Config{
+				ClientID:              "client2",
+				SkipExpiryCheck:       true,
+				VerifyAuthorizedParty: true,
+			},
+			signKey: newRSAKey(t),
+			wantErr: true,
+		},
+		{
+			name:    "multi audience azp match accepted when enabled",
+			idToken: `{"iss":"https://foo","aud":["client1","client2"],"azp":"client2"}`,
+			config: Config{
+				ClientID:              "client2",
+				SkipExpiryCheck:       true,
+				VerifyAuthorizedParty: true,
+			},
+			signKey: newRSAKey(t),
+		},
+		{
+			name:    "single audience azp mismatch rejected when enabled",
+			idToken: `{"iss":"https://foo","aud":"client2","azp":"client1"}`,
+			config: Config{
+				ClientID:              "client2",
+				SkipExpiryCheck:       true,
+				VerifyAuthorizedParty: true,
+			},
+			signKey: newRSAKey(t),
+			wantErr: true,
+		},
+		{
+			name:    "single audience azp match accepted when enabled",
+			idToken: `{"iss":"https://foo","aud":"client2","azp":"client2"}`,
+			config: Config{
+				ClientID:              "client2",
+				SkipExpiryCheck:       true,
+				VerifyAuthorizedParty: true,
+			},
+			signKey: newRSAKey(t),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, test.run)
+	}
+}
+
 func TestVerifySigningAlg(t *testing.T) {
 	tests := []verificationTest{
 		{


### PR DESCRIPTION
this adds an opt-in verifier option to validate the "azp" (authorized party) claim against Config.ClientID.

when Config.VerifyAuthorizedParty is enabled:
- if aud has multiple values, azp must be present and equal to ClientID
- if azp is present, it must be equal to ClientID

default behavior is unchanged.

refs: #355, oidc core id token validation https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation