### PR TITLE
oidc: expose typed error and sentinel for issuer-mismatch failures

### DIFF
--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -40,6 +40,31 @@ var (
 	errInvalidAtHash = errors.New("access token hash does not match value in ID token")
 )
 
+// ErrIssuerMismatch is returned by NewProvider when the issuer URL the client
+// dialed doesn't match the one published by the discovery document. It's a
+// sentinel for use with errors.Is. Callers that need the offending values
+// can errors.As into [*IssuerMismatchError].
+var ErrIssuerMismatch = errors.New("oidc: issuer URL did not match the issuer URL returned by provider")
+
+// IssuerMismatchError captures the discovery-time issuer mismatch and the
+// two values involved. Its Error string matches the legacy message format
+// for backwards compatibility.
+type IssuerMismatchError struct {
+	// Provided is the issuer URL the client used to dial discovery.
+	Provided string
+	// Discovered is the issuer URL the provider's discovery document returned.
+	Discovered string
+}
+
+func (e *IssuerMismatchError) Error() string {
+	return fmt.Sprintf("oidc: issuer URL provided to client (%q) did not match the issuer URL returned by provider (%q)", e.Provided, e.Discovered)
+}
+
+// Is reports whether target is [ErrIssuerMismatch].
+func (e *IssuerMismatchError) Is(target error) bool {
+	return target == ErrIssuerMismatch
+}
+
 type contextKey int
 
 var issuerURLKey contextKey
@@ -267,7 +292,7 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 		issuerURL = issuer
 	}
 	if p.Issuer != issuerURL && !skipIssuerValidation {
-		return nil, fmt.Errorf("oidc: issuer URL provided to client (%q) did not match the issuer URL returned by provider (%q)", issuer, p.Issuer)
+		return nil, &IssuerMismatchError{Provided: issuer, Discovered: p.Issuer}
 	}
 	var algs []string
 	for _, a := range p.Algorithms {

--- a/oidc/oidc_test.go
+++ b/oidc/oidc_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -341,6 +342,45 @@ func TestNewProvider(t *testing.T) {
 					p.algorithms, test.wantAlgorithms)
 			}
 		})
+	}
+}
+
+func TestNewProviderIssuerMismatchTypedError(t *testing.T) {
+	const discovered = "https://example.com"
+	disco := fmt.Sprintf(`{
+		"issuer": %q,
+		"authorization_endpoint": "https://example.com/auth",
+		"token_endpoint": "https://example.com/token",
+		"jwks_uri": "https://example.com/keys",
+		"id_token_signing_alg_values_supported": ["RS256"]
+	}`, discovered)
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(disco))
+	}))
+	defer s.Close()
+
+	_, err := NewProvider(context.Background(), s.URL)
+	if err == nil {
+		t.Fatal("expected NewProvider to return an error for mismatched issuer")
+	}
+	if !errors.Is(err, ErrIssuerMismatch) {
+		t.Errorf("errors.Is(err, ErrIssuerMismatch) = false, want true; err = %v", err)
+	}
+	var mismatch *IssuerMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("errors.As did not unwrap to *IssuerMismatchError; err = %v", err)
+	}
+	if mismatch.Provided != s.URL {
+		t.Errorf("Provided = %q, want %q", mismatch.Provided, s.URL)
+	}
+	if mismatch.Discovered != discovered {
+		t.Errorf("Discovered = %q, want %q", mismatch.Discovered, discovered)
 	}
 }
 


### PR DESCRIPTION
Fixes #471.

`NewProvider` returned a plain `fmt.Errorf` when the discovered issuer didn't match the one we dialed, so callers (and tests) could only react to it via brittle string matching.

This PR:
- adds `var ErrIssuerMismatch` as a sentinel for `errors.Is`.
- adds `type IssuerMismatchError struct { Provided, Discovered string }` so callers can `errors.As` and inspect the offending values.
- swaps the return site to use the typed error. `Error()` keeps the legacy format verbatim so existing string-match consumers still pass.

Regression test covers both `errors.Is` and `errors.As` paths.

Happy to apply the same treatment to the other validation messages called out in the issue (audience mismatch, unsupported alg, malformed JWT) in a follow-up if you'd like.