### PR TITLE
feat(oidc): rate-limit remote JWKS fetches every 30s

### DIFF
--- a/oidc/jwks.go
+++ b/oidc/jwks.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
 )
@@ -72,6 +73,11 @@ func newRemoteKeySet(ctx context.Context, jwksURL string) *RemoteKeySet {
 	}
 }
 
+// remoteKeyFetchInterval is the minimum time between remote JWKS fetches.
+// It caps how often unknown key IDs can trigger HTTP GETs, preventing remote
+// endpoint flooding from JWTs carrying arbitrary kid values.
+const remoteKeyFetchInterval = 30 * time.Second
+
 // RemoteKeySet is a KeySet implementation that validates JSON web tokens against
 // a jwks_uri endpoint.
 type RemoteKeySet struct {
@@ -89,6 +95,19 @@ type RemoteKeySet struct {
 
 	// A set of cached keys.
 	cachedKeys []jose.JSONWebKey
+
+	// lastFetch records when the most recent remote fetch was initiated.
+	lastFetch time.Time
+
+	// now returns the current time. Defaults to time.Now; overridable in tests.
+	now func() time.Time
+}
+
+func (r *RemoteKeySet) timeNow() time.Time {
+	if r.now != nil {
+		return r.now()
+	}
+	return time.Now()
 }
 
 // inflight is used to wait on some in-flight request from multiple goroutines.
@@ -193,11 +212,23 @@ func (r *RemoteKeySet) keysFromCache() (keys []jose.JSONWebKey) {
 
 // keysFromRemote syncs the key set from the remote set, records the values in the
 // cache, and returns the key set.
+//
+// At most one remote fetch is initiated per remoteKeyFetchInterval. When a
+// fetch was performed recently, the cached keys are returned immediately to
+// bound how often unknown kid values can cause outbound HTTP GETs.
 func (r *RemoteKeySet) keysFromRemote(ctx context.Context) ([]jose.JSONWebKey, error) {
 	// Need to lock to inspect the inflight request field.
 	r.mu.Lock()
 	// If there's not a current inflight request, create one.
 	if r.inflight == nil {
+		// Rate-limit: if a fetch was started within the last interval, return
+		// the cached keys without hitting the remote.
+		if now := r.timeNow(); !r.lastFetch.IsZero() && now.Sub(r.lastFetch) < remoteKeyFetchInterval {
+			keys := r.cachedKeys
+			r.mu.Unlock()
+			return keys, nil
+		}
+		r.lastFetch = r.timeNow()
 		r.inflight = newInflight()
 
 		// This goroutine has exclusive ownership over the current inflight

--- a/oidc/jwks_test.go
+++ b/oidc/jwks_test.go
@@ -254,11 +254,14 @@ func TestRotation(t *testing.T) {
 	s := httptest.NewServer(server)
 	defer s.Close()
 
+	fakeNow := time.Now()
 	rks := newRemoteKeySet(ctx, s.URL)
+	rks.now = func() time.Time { return fakeNow }
 
 	if _, err := rks.verify(ctx, jws1); err != nil {
 		t.Errorf("failed to verify valid signature: %v", err)
 	}
+	fakeNow = fakeNow.Add(remoteKeyFetchInterval)
 	if _, err := rks.verify(ctx, jws2); err == nil {
 		t.Errorf("incorrectly verified signature")
 	}
@@ -267,6 +270,9 @@ func TestRotation(t *testing.T) {
 	server.keys = jose.JSONWebKeySet{
 		Keys: []jose.JSONWebKey{key1.jwk(), key2.jwk()},
 	}
+
+	// Advance time past the rate-limit window so the next miss triggers a fetch.
+	fakeNow = fakeNow.Add(remoteKeyFetchInterval)
 
 	if _, err := rks.verify(ctx, jws1); err != nil {
 		t.Errorf("failed to verify valid signature: %v", err)
@@ -283,6 +289,64 @@ func TestRotation(t *testing.T) {
 	}
 	if _, err := rks.verify(ctx, jws2); err != nil {
 		t.Errorf("failed to verify valid signature: %v", err)
+	}
+}
+
+func TestRemoteKeySetRateLimit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	key := newRSAKey(t)
+	key.keyID = "known"
+
+	unknown := newRSAKey(t)
+	unknown.keyID = "unknown"
+
+	payload := []byte("test payload")
+	jwsUnknown, err := jose.ParseSigned(unknown.sign(t, payload), allAlgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fetchCount := 0
+	server := &keyServer{keys: jose.JSONWebKeySet{Keys: []jose.JSONWebKey{key.jwk()}}}
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount++
+		server.ServeHTTP(w, r)
+	}))
+	defer s.Close()
+
+	fakeNow := time.Now()
+	rks := newRemoteKeySet(ctx, s.URL)
+	rks.now = func() time.Time { return fakeNow }
+
+	// First verify with unknown kid
+	// triggers one remote fetch, returns cache-miss error.
+	if _, err := rks.verify(ctx, jwsUnknown); err == nil {
+		t.Fatal("expected verification failure for unknown kid")
+	}
+	if fetchCount != 1 {
+		t.Fatalf("expected 1 fetch, got %d", fetchCount)
+	}
+
+	// Repeated verifies with unknown kid within the rate-limit window must not
+	// trigger additional fetches.
+	for i := 0; i < 10; i++ {
+		if _, err := rks.verify(ctx, jwsUnknown); err == nil {
+			t.Fatal("expected verification failure for unknown kid")
+		}
+	}
+	if fetchCount != 1 {
+		t.Fatalf("expected still 1 fetch after rapid retries, got %d", fetchCount)
+	}
+
+	// After the window expires a new fetch is allowed.
+	fakeNow = fakeNow.Add(remoteKeyFetchInterval)
+	if _, err := rks.verify(ctx, jwsUnknown); err == nil {
+		t.Fatal("expected verification failure for unknown kid")
+	}
+	if fetchCount != 2 {
+		t.Fatalf("expected 2 fetches after interval elapsed, got %d", fetchCount)
 	}
 }
 


### PR DESCRIPTION
## Description:

This is a suggestion to limit the risk of flooding a remote with requests to get keys for a JWT that is using a random/unknown KID.

Currently an unknown KID triggers a fetch to the remote to update the cached keys which respects the openid specs
https://openid.net/specs/openid-connect-core-1_0.html#RotateSigKeys

> Keys can be rolled over by periodically adding new keys to the JWK Set at the jwks_uri location. The signer can begin using a new key at its discretion and signals the change to the verifier using the kid value. The verifier knows to go back to the jwks_uri location to re-retrieve the keys when it sees an unfamiliar kid value

Yet, in case of a unexpected JWTs hitting the server with a random KID, it might lead to elevated fetches on the remote. 


For JWKS setup, 30s is expected to be really fair. New keys are usually not expected to be created that often nor used right away.
- For server **without** any unexpected KID check:
  - a new KID will trigger an update of the cache, 0 errors
- For a server **with** unexpected KID check:
  - a new KID introduced and directly used (edge case) might create errors for up to 30s if the cache was wrongly refreshed on an invalid JWKS

Note: jose JS implementation does use 30s as well by default https://github.com/panva/jose/blob/a90ad6e683efb74539235b2363d1f3bda3ab6ce1/src/jwks/remote.ts#L261-L265 

## Changes: 
Prevent JWTs with arbitrary kid values from flooding the remote JWKS endpoint. keysFromRemote now skips the HTTP GET and returns cached keys if a succesful fetch was initiated within the last 30 seconds. 
