### PR TITLE
fix: Key refresh should set `no-cache` to get most up to date keys

### DIFF
--- a/oidc/jwks.go
+++ b/oidc/jwks.go
@@ -238,6 +238,7 @@ func (r *RemoteKeySet) updateKeys() ([]jose.JSONWebKey, error) {
 	if err != nil {
 		return nil, fmt.Errorf("oidc: can't create request: %v", err)
 	}
+	req.Header.Set("Cache-Control", "no-cache")
 
 	resp, err := doRequest(r.ctx, req)
 	if err != nil {

--- a/oidc/jwks_test.go
+++ b/oidc/jwks_test.go
@@ -286,6 +286,46 @@ func TestRotation(t *testing.T) {
 	}
 }
 
+func TestUpdateKeysSendsCacheControlNoCache(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	key := newRSAKey(t)
+	var requestHeaders []http.Header
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestHeaders = append(requestHeaders, r.Header.Clone())
+		if err := json.NewEncoder(w).Encode(jose.JSONWebKeySet{
+			Keys: []jose.JSONWebKey{key.jwk()},
+		}); err != nil {
+			panic(err)
+		}
+	}))
+	defer s.Close()
+
+	rks := newRemoteKeySet(ctx, s.URL)
+
+	payload := []byte("a secret")
+	jws, err := jose.ParseSigned(key.sign(t, payload), allAlgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := rks.verify(ctx, jws); err != nil {
+		t.Fatalf("failed to verify: %v", err)
+	}
+
+	if len(requestHeaders) == 0 {
+		t.Fatal("expected at least one request to the JWKS endpoint")
+	}
+	for i, h := range requestHeaders {
+		if got := h.Get("Cache-Control"); got != "no-cache" {
+			t.Errorf("request %d: expected Cache-Control: no-cache, got %q", i, got)
+		}
+	}
+}
+
+
 func BenchmarkVerify(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Currently, the HTTP client fetches the keys without a `Cache-Control` header. This can lead to potential issues because, with the current logic, we always attempt to revalidate when we encounter an unknown `kid`. Therefore, we want to ensure that we retrieve the most up-to-date keys from the OIDC server.

For this reason, we should include a `Cache-Control: no-cache` header in the request to ensure that the keys are revalidated and that we do not receive a stale key set from an intermediary proxy.

Fixes #484 