### PR TITLE
oidc: add support for validating back-channel logout tokens

### DIFF
--- a/example/logout/README.md
+++ b/example/logout/README.md
@@ -1,0 +1,61 @@
+# Logout example app
+
+This logout example app demonstrates use of the logout endpoint. As opposed to
+the other example apps, it runs against Auth0 rather than Google. This works
+best with:
+
+- An Auth0 [developer instance][auth0-dev].
+- A [Tailscale funnel][tailscale-funnel] or [Cloudflare Tunnel][cloudflare-tunnel]
+  to advertise a local logout endpoint on the internet.
+
+[auth0-dev]: https://developer.auth0.com/
+[cloudflare-tunnel]: https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/
+[tailscale-funnel]: https://tailscale.com/docs/features/tailscale-funnel
+
+Using Tailscale, the tunnel will advertise on a DNS name like:
+
+```
+BASE_URL="https://${MY_HOST}.ts.net"
+```
+
+Within the Auth0 application, configure "Allowed Callback URLs" with the
+following value:
+
+```
+${BASE_URL}/callback
+```
+
+And "Back-Channel Logout URI" with:
+
+```
+${BASE_URL}/logout
+```
+
+Then run the logout app with:
+
+```
+export CLIENT_ID="{AUTH0_CLIENT_ID}"
+export CLIENT_SECRET="{AUTH0_CLIENT_SECRET}"
+go run ./example/logout/app.go \
+    --base-url="${BASE_URL}" \
+    --issuer-url="${AUTH0_ISSUER_URL}"
+```
+
+After logging into the app, there will be a "Logout" link at the bottom of the
+page that performs RP-Initiated Logout. Clicking on that link, you will logout
+through Auth0, and trigger a POST to the logout endpoint.
+
+Once the app receives the logout token, it will validate it and log a message:
+
+```
+2026/06/17 13:06:39 Logout token: {
+  "Issuer": "${AUTH0_ISSUER_URL}",
+  "Subject": "1234",
+  "Audience": [
+    "${CLIENT_ID}"
+  ],
+  "IssuedAt": "2026-06-17T13:06:39-07:00",
+  "Expiry": "2026-06-17T13:08:39-07:00",
+  "SessionID": "Kaeo_qJ9zFDcWI9g_fNVa24rv7uu1gpV"
+}
+```

--- a/example/logout/app.go
+++ b/example/logout/app.go
@@ -1,0 +1,237 @@
+/*
+This is an example application to demonstrate parsing an ID Token.
+*/
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"html/template"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+)
+
+var (
+	clientID     = os.Getenv("CLIENT_ID")
+	clientSecret = os.Getenv("CLIENT_SECRET")
+)
+
+func randString(nByte int) (string, error) {
+	b := make([]byte, nByte)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func setCallbackCookie(w http.ResponseWriter, r *http.Request, name, value string) {
+	c := &http.Cookie{
+		Name:     name,
+		Value:    value,
+		MaxAge:   int(time.Hour.Seconds()),
+		Secure:   r.TLS != nil,
+		HttpOnly: true,
+	}
+	http.SetCookie(w, c)
+}
+
+func main() {
+	var (
+		baseURL   string
+		issuerURL string
+		port      uint64
+	)
+	flag.StringVar(&baseURL, "base-url", "",
+		"Base URL that the server is running on such as 'https://example.com'")
+	flag.Uint64Var(&port, "port", 3000,
+		"Port to serve locally.")
+	flag.StringVar(&issuerURL, "issuer-url", "",
+		"OpenID Connect Issuer URL to listen for")
+	flag.Parse()
+	if baseURL == "" {
+		log.Fatalf("No --base-url provided")
+	}
+	if issuerURL == "" {
+		log.Fatalf("No --issuer-url provided")
+	}
+	if clientID == "" {
+		log.Fatalf("No CLIENT_ID environment variable set")
+	}
+	if clientSecret == "" {
+		log.Fatalf("No CLIENT_SECRET environment variable set")
+	}
+
+	ctx := context.Background()
+
+	callbackURL, err := url.JoinPath(baseURL, "/callback")
+	if err != nil {
+		log.Fatalf("Generating callback URL: %v", err)
+	}
+
+	provider, err := oidc.NewProvider(ctx, issuerURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var metadata struct {
+		EndSessionEndpoint string `json:"end_session_endpoint"`
+	}
+	if err := provider.Claims(&metadata); err != nil {
+		log.Fatalf("Parsing metadata: %v", err)
+	}
+	if metadata.EndSessionEndpoint == "" {
+		log.Fatalf("Provider doesn't have end_session_endpoint")
+	}
+
+	oidcConfig := &oidc.Config{
+		ClientID: clientID,
+	}
+	verifier := provider.Verifier(oidcConfig)
+
+	config := oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Endpoint:     provider.Endpoint(),
+		RedirectURL:  callbackURL,
+		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+	}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		state, err := randString(16)
+		if err != nil {
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
+		nonce, err := randString(16)
+		if err != nil {
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
+		setCallbackCookie(w, r, "state", state)
+		setCallbackCookie(w, r, "nonce", nonce)
+
+		http.Redirect(w, r, config.AuthCodeURL(state, oidc.Nonce(nonce)), http.StatusFound)
+	})
+
+	http.HandleFunc("POST /logout", func(w http.ResponseWriter, r *http.Request) {
+		token := r.PostFormValue("logout_token")
+		if token == "" {
+			log.Println("No logout_token")
+			http.Error(w, "No logout token", http.StatusBadRequest)
+			return
+		}
+		logoutToken, err := verifier.VerifyLogout(r.Context(), token)
+		if err != nil {
+			log.Printf("Failed to validate logout token: %v", err)
+			http.Error(w, "Invalid logout token", http.StatusBadRequest)
+			return
+		}
+		data, _ := json.MarshalIndent(logoutToken, "", "  ")
+		log.Printf("Logout token: %s", data)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	http.HandleFunc("GET /callback", func(w http.ResponseWriter, r *http.Request) {
+		state, err := r.Cookie("state")
+		if err != nil {
+			http.Error(w, "state not found", http.StatusBadRequest)
+			return
+		}
+		if r.URL.Query().Get("state") != state.Value {
+			http.Error(w, "state did not match", http.StatusBadRequest)
+			return
+		}
+
+		oauth2Token, err := config.Exchange(ctx, r.URL.Query().Get("code"))
+		if err != nil {
+			http.Error(w, "Failed to exchange token: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rawIDToken, ok := oauth2Token.Extra("id_token").(string)
+		if !ok {
+			http.Error(w, "No id_token field in oauth2 token.", http.StatusInternalServerError)
+			return
+		}
+		idToken, err := verifier.Verify(ctx, rawIDToken)
+		if err != nil {
+			http.Error(w, "Failed to verify ID Token: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		nonce, err := r.Cookie("nonce")
+		if err != nil {
+			http.Error(w, "nonce not found", http.StatusBadRequest)
+			return
+		}
+		if idToken.Nonce != nonce.Value {
+			http.Error(w, "nonce did not match", http.StatusBadRequest)
+			return
+		}
+
+		oauth2Token.AccessToken = "*REDACTED*"
+
+		resp := struct {
+			OAuth2Token   *oauth2.Token
+			IDTokenClaims *json.RawMessage // ID Token payload is just JSON.
+		}{oauth2Token, new(json.RawMessage)}
+
+		if err := idToken.Claims(&resp.IDTokenClaims); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		data, err := json.MarshalIndent(resp, "", "    ")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		endSessionEndpoint, err := url.Parse(metadata.EndSessionEndpoint)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to parse end session endpoint :%v", err), http.StatusInternalServerError)
+			return
+		}
+		v := endSessionEndpoint.Query()
+		v.Add("id_token_hint", rawIDToken)
+		endSessionEndpoint.RawQuery = v.Encode()
+		d := tmplData{
+			Payload:   string(data),
+			LoginURL:  baseURL,
+			LogoutURL: endSessionEndpoint.String(),
+		}
+		tmpl.Execute(w, d)
+	})
+
+	log.Printf("listening on http://[::]:%d", port)
+	log.Fatal(http.ListenAndServe(":"+strconv.FormatUint(port, 10), nil))
+}
+
+type tmplData struct {
+	Payload   string
+	LoginURL  string
+	LogoutURL string
+}
+
+var tmpl = template.Must(template.New("").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>go-oidc</title>
+</head>
+<body>
+	<pre>
+    	<code>{{.Payload}}</code>
+	</pre>
+	<a href="{{.LoginURL}}">Reauth</a>
+	<a href="{{.LogoutURL}}">Logout</a>
+</body>
+</html>`))

--- a/oidc/logout.go
+++ b/oidc/logout.go
@@ -1,0 +1,187 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// LogoutToken represents a verified token from a Back-Channel Logout. Use
+// [IDTokenVerifier.VerifyLogout] within a POST handler to receive and validate
+// a token.
+//
+// See the ./example/logout at the top-level of this repo for a full example
+// application.
+type LogoutToken struct {
+	// The required token ID claim ("jti"). When processing this token for
+	// logout, applications should validate that no recent token with the same
+	// value has been processed.
+	TokenID string
+	// The unique identifier of the user that this logout token is for. This
+	// will match the subject value of the ID Token.
+	//
+	// If not set, SessionID will be.
+	Subject string
+
+	// The "iss" claim. This is validated against the provider URL unless
+	// explicitly skipped through SkipIssuerCheck.
+	Issuer string
+	// The Client ID this logout token is for. Validated against the config
+	// unless SkipClientIDCheck is provided.
+	Audience []string
+	// When this token was issued.
+	IssuedAt time.Time
+	// When this token expires. Validated unless SkipExpiryCheck is provided.
+	Expiry time.Time
+	// Optional session ID claim ("sid").
+	//
+	// The exact semantics of session IDs very between identity providers. Use
+	// your provider's documentation to determine what this correlates to and
+	// how it should be handled.
+	SessionID string
+
+	claims []byte
+}
+
+// Claims unmarshals the raw JSON payload of the Logout Token into a provided
+// struct. This can be used to access field not exposed by the LogoutToken
+// fields.
+//
+//	logoutToken, err := idTokenVerifier.VerifyLogout(ctx, rawLogoutToken)
+//	if err != nil{
+//		// ...
+//	}
+//	var claims struct {
+//		TraceID string `json:"trace_id"`
+//	}
+//	if err := logoutToken.Claims(&claims); err != nil {
+//		// ...
+//	}
+func (l *LogoutToken) Claims(v any) error {
+	if l.claims == nil {
+		return errors.New("oidc: claims not set")
+	}
+	return json.Unmarshal(l.claims, v)
+}
+
+// https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken
+type logoutTokenJSON struct {
+	Issuer   string   `json:"iss"`
+	Subject  string   `json:"sub"`
+	Audience audience `json:"aud"`
+	Expiry   jsonTime `json:"exp"`
+	IssuedAt jsonTime `json:"iat"`
+	JTI      string   `json:"jti"`
+	Events   struct {
+		Logout json.RawMessage `json:"http://schemas.openid.net/event/backchannel-logout"`
+	}
+	SessionID string `json:"sid"`
+	// Nonce is parsed as a raw message so its mere presence can be detected.
+	// The spec requires logout tokens to not contain a nonce claim, regardless
+	// of its value.
+	Nonce json.RawMessage `json:"nonce"`
+}
+
+// VerifyLogout validates a back-channel logout token. Logout tokens are
+// received by the relying party (this package) from the identity provider at a
+// preconfigured "backchannel_logout_uri" through a POST. Then on certain
+// events, such as RP-Initiated Logout, the identity provider will send a signed
+// token indicating that sessions for a specific user should be terminated.
+//
+// To support back-channel logout within your app, register a POST endpoint and
+// verify the token:
+//
+//	oidcConfig := &oidc.Config{
+//		ClientID: clientID,
+//	}
+//	verifier := provider.Verifier(oidcConfig)
+//
+//	mux.HandleFunc("POST /logout", func(w http.ResponseWriter, r *http.Reequest) {
+//		rawLogoutToken := r.PostFormValue("logout_token")
+//		if rawLogoutToken == "" {
+//			// ...
+//		}
+//		logoutToken, err := verifier.VerifyLogout(r.Context(), rawLogoutToken)
+//		if err != nil {
+//			// ...
+//		}
+//		// Use fields in the logoutToken to determine what sessions to
+//		// terminate.
+//
+//	})
+//
+// Back-channel logout spec: https://openid.net/specs/openid-connect-backchannel-1_0.html
+//
+// RP-initiated logout spec: https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+func (v *IDTokenVerifier) VerifyLogout(ctx context.Context, rawLogoutToken string) (*LogoutToken, error) {
+	payload, _, err := v.verifyJWT(ctx, rawLogoutToken)
+	if err != nil {
+		return nil, err
+	}
+	var logoutToken logoutTokenJSON
+	if err := json.Unmarshal(payload, &logoutToken); err != nil {
+		return nil, fmt.Errorf("oidc: parsing logout token payload: %v", err)
+	}
+
+	if len(logoutToken.Events.Logout) == 0 {
+		return nil, fmt.Errorf("oidc: logout token missing required http://schemas.openid.net/event/backchannel-logout event")
+	}
+
+	// A logout token MUST NOT contain a nonce claim. This prevents an ID token
+	// from being replayed as a logout token.
+	if len(logoutToken.Nonce) != 0 {
+		return nil, fmt.Errorf("oidc: logout token must not contain a 'nonce' claim")
+	}
+
+	t := &LogoutToken{
+		Issuer:    logoutToken.Issuer,
+		Subject:   logoutToken.Subject,
+		Audience:  logoutToken.Audience,
+		IssuedAt:  time.Time(logoutToken.IssuedAt),
+		Expiry:    time.Time(logoutToken.Expiry),
+		SessionID: logoutToken.SessionID,
+		TokenID:   logoutToken.JTI,
+		claims:    payload,
+	}
+	if t.TokenID == "" {
+		return nil, fmt.Errorf("oidc: logout token missing required claim 'jti'")
+	}
+	if t.Expiry.IsZero() {
+		return nil, fmt.Errorf("oidc: logout token must contain an 'exp' claim")
+	}
+
+	// A logout token MUST contain a 'sub' claim, a 'sid' claim, or both.
+	if t.Subject == "" && t.SessionID == "" {
+		return nil, fmt.Errorf("oidc: logout token must contain a 'sub' claim, a 'sid' claim, or both")
+	}
+
+	if !v.config.SkipIssuerCheck && t.Issuer != v.issuer {
+		return nil, fmt.Errorf("oidc: logout token issued by a different provider, expected %q, got %q", v.issuer, t.Issuer)
+	}
+
+	if !v.config.SkipClientIDCheck {
+		if v.config.ClientID != "" {
+			if !contains(t.Audience, v.config.ClientID) {
+				return nil, fmt.Errorf("oidc: expected logout token audience %q got %q", v.config.ClientID, t.Audience)
+			}
+		} else {
+			return nil, fmt.Errorf("oidc: invalid configuration, clientID must be provided or SkipClientIDCheck must be set")
+		}
+	}
+
+	// If a SkipExpiryCheck is false, make sure token is not expired.
+	if !v.config.SkipExpiryCheck {
+		now := time.Now
+		if v.config.Now != nil {
+			now = v.config.Now
+		}
+		nowTime := now()
+
+		if t.Expiry.Before(nowTime) {
+			return nil, &TokenExpiredError{Expiry: t.Expiry}
+		}
+	}
+	return t, nil
+}

--- a/oidc/logout_test.go
+++ b/oidc/logout_test.go
@@ -1,0 +1,534 @@
+package oidc
+
+import (
+	"crypto"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+)
+
+const auth0JWTs = `{
+  "keys": [
+    {
+      "kty": "RSA",
+      "use": "sig",
+      "n": "uv7NSwCelgZ7nAOxKM27fUHKJrIIL-UreZ0wz5MRvfoQQXcaOnjpcSoBX1FwTXH01MPKhPJMJkMFpDfdT7IxMgdq_SLBGz73FRabahOXbItyEvOPf6oXmJJB3vh3at-G7dWRGOa3YC8gXw_2V7OgAh2X4UyqB40hjlvM8bjtbK8QBZGGbw2h-7Hp8GTa5iZXjqd_o6e9zhqzVCOSj-DOQYp8EqlW0gBQu-4-WDgnK0VwBCuaFGqznKg0HjM4FS4qCVYmLIFX3k2ibpwHncEvTPTJ3LMN7WBElM5jIpW5mVKFrgiM2dgfGbfE1uTSwep8507SBj3d0PAmHomFoCzGDQ",
+      "e": "AQAB",
+      "kid": "MJEenCzYAP_m5TgvpAPya",
+      "x5t": "e5j-NuV3qV9pTuGiO619QS0E04Q",
+      "x5c": [
+        "MIIDHTCCAgWgAwIBAgIJXRuvBG90F7xrMA0GCSqGSIb3DQEBCwUAMCwxKjAoBgNVBAMTIWRldi0xenp2ZTQxcDFjZWM3eDFqLnVzLmF1dGgwLmNvbTAeFw0yNjA2MTcxNzM4MTNaFw00MDAyMjQxNzM4MTNaMCwxKjAoBgNVBAMTIWRldi0xenp2ZTQxcDFjZWM3eDFqLnVzLmF1dGgwLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALr+zUsAnpYGe5wDsSjNu31ByiayCC/lK3mdMM+TEb36EEF3Gjp46XEqAV9RcE1x9NTDyoTyTCZDBaQ33U+yMTIHav0iwRs+9xUWm2oTl2yLchLzj3+qF5iSQd74d2rfhu3VkRjmt2AvIF8P9lezoAIdl+FMqgeNIY5bzPG47WyvEAWRhm8Nofux6fBk2uYmV46nf6Onvc4as1Qjko/gzkGKfBKpVtIAULvuPlg4JytFcAQrmhRqs5yoNB4zOBUuKglWJiyBV95Nom6cB53BL0z0ydyzDe1gRJTOYyKVuZlSha4IjNnYHxm3xNbk0sHqfOdO0gY93dDwJh6JhaAsxg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUxIt/DkLyNhKm86E5OO9racAMyb4wDgYDVR0PAQH/BAQDAgKEMA0GCSqGSIb3DQEBCwUAA4IBAQC0gbuBuECbkfqsfls0I+Nni1kodTJSRK9LgDPkk/dN68j6fqDoiXr/qnLAYjv3vdvVTHn+bJ01iv9F23uW0umHQ4QXB0nd6lZqy33RVLVaFCRX0n1sJEf7Uwz+MROqxE1nlZSxPwiLUYsXuCut2q5NDybNlw6FSlO8BDohTQvpmVu2RDnFfG9as5LC80nmnfdWjiHfM+r9P7sjqkZvuulTQcgmHe29CqOKI2PZWV6CZlqleY3c9Ub7qJQ4mwmkpaJvyA7j81H7R2DAx61hR6glXHnvF6s/7Qt6TAVW1SNbR4+8bBDRBzJcyOmaaLw/rCglOVWW70ZoE28a9iVy5owO"
+      ],
+      "alg": "RS256"
+    },
+    {
+      "kty": "RSA",
+      "use": "sig",
+      "n": "1MPL8fuaTURFBZSwPGDVs8sxOkHs0rUX0s82GttwXNtC0WpU4HeNqha5LCW5Rot0rx2JOPGzgzLbiw7z1TfqNuG3w9nV16U7-CQM65d78vgw6qZ2-MEzc_6eOundchXlHu67DWEkaf61NPJ-zfE2I2wb_VWhhoxuJSxX6b2X9arMzNfc9-0vcwgVQsNTVU6G-OrHVoZu2O-d95nf_3XDlHxH_GOA2Wplf9LmiFwyQBKAHgAs7GWZ1Jmp4Br8dp8ZiRb_FMAYZLN0jRxEPjITsopEuStq819qg7Mf0QF4Ba6cIaleQ6CO54CHcNKXtw9j3Vc1mkUJ3ERInT-705g_fw",
+      "e": "AQAB",
+      "kid": "at8QtR6iDf7Cct4M75uyQ",
+      "x5t": "0RZ_EexHYMHWQOeDs0Pw_aAH4Eg",
+      "x5c": [
+        "MIIDHTCCAgWgAwIBAgIJFCeir1tXEr02MA0GCSqGSIb3DQEBCwUAMCwxKjAoBgNVBAMTIWRldi0xenp2ZTQxcDFjZWM3eDFqLnVzLmF1dGgwLmNvbTAeFw0yNjA2MTcxNzM4MTNaFw00MDAyMjQxNzM4MTNaMCwxKjAoBgNVBAMTIWRldi0xenp2ZTQxcDFjZWM3eDFqLnVzLmF1dGgwLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANTDy/H7mk1ERQWUsDxg1bPLMTpB7NK1F9LPNhrbcFzbQtFqVOB3jaoWuSwluUaLdK8diTjxs4My24sO89U36jbht8PZ1delO/gkDOuXe/L4MOqmdvjBM3P+njrp3XIV5R7uuw1hJGn+tTTyfs3xNiNsG/1VoYaMbiUsV+m9l/WqzMzX3PftL3MIFULDU1VOhvjqx1aGbtjvnfeZ3/91w5R8R/xjgNlqZX/S5ohcMkASgB4ALOxlmdSZqeAa/HafGYkW/xTAGGSzdI0cRD4yE7KKRLkravNfaoOzH9EBeAWunCGpXkOgjueAh3DSl7cPY91XNZpFCdxESJ0/u9OYP38CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUOpacqHH7kmg51Sp5DpYPiVKed9gwDgYDVR0PAQH/BAQDAgKEMA0GCSqGSIb3DQEBCwUAA4IBAQB8M9poQXm6AHgZZjJmDJ3fbPT+aM8cuih0wAzjo92JFBc81xO3gU9z1i9gEqySzZ0RTlwKGUoM8J55sTB0v+FEu4XV94xD6ttlYarr0JMi+0C3uH2C/KURpmAmZeWaP+fe3t6QSlpz9d4tl+OHJqVpmqCJSu8x3Jc+dATq4EkEBj1d/keF/bg2nkBt4NOh0bz6UMUCOhGcCUJNeZR6wa7DwjVMorvED6GAHipot5aNC4/8SR5ubC7p12ZYLDusr1sOxSfqjk0K4I+LeyrKMprw7gkOvjLEvmyWkCdO4yHq2ibYBSLTiyhEO2xn9VQuogtUXh13DKXp6vEMeMcL378/"
+      ],
+      "alg": "RS256"
+    }
+  ]
+}`
+
+// Token received from an Auth0 logout POST.
+const auth0LogoutToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik1KRWVuQ3pZQVBfbTVUZ3ZwQVB5YSJ9.eyJpc3MiOiJodHRwczovL2Rldi0xenp2ZTQxcDFjZWM3eDFqLnVzLmF1dGgwLmNvbS8iLCJzdWIiOiJnb29nbGUtb2F1dGgyfDExMjkxODk2MDE1NTk4NzMyMzM2MSIsImF1ZCI6IlpIVFpyZm50ZlBqWVpESmlJTUIxa2ViMEhIQTlBS0V2IiwiaWF0IjoxNzgxNzI0ODk3LCJleHAiOjE3ODE3MjUwMTcsImp0aSI6ImMzMWIzYTE0LTkzOTctNDRjNC04NTZhLTllYTE4ODAwOTM0NSIsImV2ZW50cyI6eyJodHRwOi8vc2NoZW1hcy5vcGVuaWQubmV0L2V2ZW50L2JhY2tjaGFubmVsLWxvZ291dCI6e319LCJ0cmFjZV9pZCI6ImEwZDQ3ZTlhYzg1YTE1YTQiLCJzaWQiOiJIRENlMENILXI2RGoyaXloVG5qc0ZwczlhX0lOckVfYyJ9.GWzDL6fKUIx_41MIkX-lRLiU9KJy7JHgV7i96PqRT5RK_8PkDMJzeKqpzbwgQat_jNbd3b3PiT-lhPDumPxurQJSKaBv09Rpuui96wp95y1S1heUDTR5YVc5HFnaVlQTOQExJMsi-yfsQiIYqgwavhOerps5Rfl37GakxzN7nYGc7-lznjdJCkaTV-goh81xIdYskKcnfxBJcPOXQmmqelQDUKusjQk_deaUQHyUGU8LONpbgxP4DGBIS6EZp5WbPKRSeimGJpd1Phycf6n4eojojnJihBBfxPaCZRTHTwrfh1-WuROVXhoRtE51FYcycWMLxM4E9JX85I9k2C0AAg"
+
+// The time this token was issued.
+const auth0IAT = 1781724897
+
+func TestAuth0Logout(t *testing.T) {
+	now := time.Unix(auth0IAT, 0)
+	clientID := "ZHTZrfntfPjYZDJiIMB1keb0HHA9AKEv"
+	issuerURL := "https://dev-1zzve41p1cec7x1j.us.auth0.com/"
+	var jwks struct {
+		Keys []*jose.JSONWebKey `json:"keys"`
+	}
+	if err := json.Unmarshal([]byte(auth0JWTs), &jwks); err != nil {
+		t.Fatalf("Parsing JWKs: %v", err)
+	}
+	var pubKeys []crypto.PublicKey
+	for _, k := range jwks.Keys {
+		pubKeys = append(pubKeys, k.Public().Key)
+	}
+
+	config := &Config{
+		ClientID: clientID,
+		Now:      func() time.Time { return now },
+	}
+	keySet := &StaticKeySet{PublicKeys: pubKeys}
+	v := NewVerifier(issuerURL, keySet, config)
+	got, err := v.VerifyLogout(t.Context(), auth0LogoutToken)
+	if err != nil {
+		t.Fatalf("Verifying logout token: %v", err)
+	}
+
+	var claims struct {
+		TraceID string `json:"trace_id"`
+	}
+	if err := got.Claims(&claims); err != nil {
+		t.Fatalf("Parsing claims: %v", err)
+	}
+	wantTraceID := "a0d47e9ac85a15a4"
+	if claims.TraceID != wantTraceID {
+		t.Errorf("Parsing claims returned unexpected trace_id, got=%s, want=%s", claims.TraceID, wantTraceID)
+	}
+
+	got.claims = nil
+	want := &LogoutToken{
+		Issuer:    "https://dev-1zzve41p1cec7x1j.us.auth0.com/",
+		Subject:   "google-oauth2|112918960155987323361",
+		Audience:  []string{"ZHTZrfntfPjYZDJiIMB1keb0HHA9AKEv"},
+		IssuedAt:  time.Unix(1781724897, 0),
+		Expiry:    time.Unix(1781725017, 0),
+		TokenID:   "c31b3a14-9397-44c4-856a-9ea188009345",
+		SessionID: "HDCe0CH-r6Dj2iyhTnjsFps9a_INrE_c",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Auth0 Logout token returned unexpected results, got=%#v, want=%#v", got, want)
+	}
+}
+
+const (
+	testLogoutIssuer   = "https://login.example.com"
+	testLogoutClientID = "test-client-id"
+	// The "iat" and "exp" used in the payloads below, along with the time
+	// returned by the test verifier's Now function (set to testLogoutIAT).
+	testLogoutIAT = 1781724897
+	testLogoutExp = 1781725017
+)
+
+func TestLogoutToken(t *testing.T) {
+	// A key used to sign tokens that is NOT in the verifier's key set, used to
+	// exercise signature validation failures.
+	unknownKey := newRSAKey(t)
+
+	tests := []struct {
+		name string
+		// The key used to sign the payload.
+		signKey *signingKey
+		// The keys the verifier trusts. If empty, defaults to signKey so that
+		// signatures verify by default.
+		verificationKeys []*signingKey
+		config           Config
+		payload          string
+
+		wantErr bool
+		want    *LogoutToken
+	}{
+		{
+			name:    "valid",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			want: &LogoutToken{
+				Issuer:    testLogoutIssuer,
+				Subject:   "user-1",
+				Audience:  []string{testLogoutClientID},
+				IssuedAt:  time.Unix(testLogoutIAT, 0),
+				Expiry:    time.Unix(testLogoutExp, 0),
+				TokenID:   "jti-1",
+				SessionID: "sid-1",
+			},
+		},
+		{
+			name:    "no session id",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			want: &LogoutToken{
+				Issuer:   testLogoutIssuer,
+				Subject:  "user-1",
+				Audience: []string{testLogoutClientID},
+				IssuedAt: time.Unix(testLogoutIAT, 0),
+				Expiry:   time.Unix(testLogoutExp, 0),
+				TokenID:  "jti-1",
+			},
+		},
+		{
+			name:    "multiple audiences",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": ["test-client-id", "test-client-id-2"],
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			want: &LogoutToken{
+				Issuer:    testLogoutIssuer,
+				Subject:   "user-1",
+				Audience:  []string{testLogoutClientID, "test-client-id-2"},
+				IssuedAt:  time.Unix(testLogoutIAT, 0),
+				Expiry:    time.Unix(testLogoutExp, 0),
+				TokenID:   "jti-1",
+				SessionID: "sid-1",
+			},
+		},
+		{
+			name:    "signed with EdDSA key",
+			signKey: newEdDSAKey(t),
+			config: Config{
+				ClientID:             testLogoutClientID,
+				SupportedSigningAlgs: []string{EdDSA},
+			},
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			want: &LogoutToken{
+				Issuer:    testLogoutIssuer,
+				Subject:   "user-1",
+				Audience:  []string{testLogoutClientID},
+				IssuedAt:  time.Unix(testLogoutIAT, 0),
+				Expiry:    time.Unix(testLogoutExp, 0),
+				TokenID:   "jti-1",
+				SessionID: "sid-1",
+			},
+		},
+		{
+			name:    "missing backchannel-logout event",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {}
+			}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing jti",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			wantErr: true,
+		},
+		{
+			name:    "issuer mismatch",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			payload: `{
+				"iss": "https://evil.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			wantErr: true,
+		},
+		{
+			name:    "skip issuer check",
+			signKey: newRSAKey(t),
+			config: Config{
+				ClientID:        testLogoutClientID,
+				SkipIssuerCheck: true,
+			},
+			payload: `{
+				"iss": "https://other.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			want: &LogoutToken{
+				Issuer:    "https://other.example.com",
+				Subject:   "user-1",
+				Audience:  []string{testLogoutClientID},
+				IssuedAt:  time.Unix(testLogoutIAT, 0),
+				Expiry:    time.Unix(testLogoutExp, 0),
+				TokenID:   "jti-1",
+				SessionID: "sid-1",
+			},
+		},
+		{
+			name:    "audience mismatch",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "some-other-client",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing client id config",
+			signKey: newRSAKey(t),
+			config:  Config{},
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			wantErr: true,
+		},
+		{
+			name:    "skip client id check",
+			signKey: newRSAKey(t),
+			config:  Config{SkipClientIDCheck: true},
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "some-other-client",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			want: &LogoutToken{
+				Issuer:    testLogoutIssuer,
+				Subject:   "user-1",
+				Audience:  []string{"some-other-client"},
+				IssuedAt:  time.Unix(testLogoutIAT, 0),
+				Expiry:    time.Unix(testLogoutExp, 0),
+				TokenID:   "jti-1",
+				SessionID: "sid-1",
+			},
+		},
+		{
+			name:    "expired token",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			// Expiry well before testLogoutIAT, the verifier's notion of "now".
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724657,
+				"exp": 1781724777,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			wantErr: true,
+		},
+		{
+			name:    "skip expiry check",
+			signKey: newRSAKey(t),
+			config: Config{
+				ClientID:        testLogoutClientID,
+				SkipExpiryCheck: true,
+			},
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724657,
+				"exp": 1781724777,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			want: &LogoutToken{
+				Issuer:    testLogoutIssuer,
+				Subject:   "user-1",
+				Audience:  []string{testLogoutClientID},
+				IssuedAt:  time.Unix(1781724657, 0),
+				Expiry:    time.Unix(1781724777, 0),
+				TokenID:   "jti-1",
+				SessionID: "sid-1",
+			},
+		},
+		{
+			name:    "missing exp",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			// A logout token must contain an "exp" claim.
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			wantErr: true,
+		},
+		{
+			name:             "signed by untrusted key",
+			signKey:          unknownKey,
+			verificationKeys: []*signingKey{newRSAKey(t)},
+			config:           Config{ClientID: testLogoutClientID},
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			wantErr: true,
+		},
+		{
+			name:    "no subject",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			// A logout token may identify the session via "sid" without a "sub".
+			payload: `{
+				"iss": "https://login.example.com",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			want: &LogoutToken{
+				Issuer:    testLogoutIssuer,
+				Audience:  []string{testLogoutClientID},
+				IssuedAt:  time.Unix(testLogoutIAT, 0),
+				Expiry:    time.Unix(testLogoutExp, 0),
+				TokenID:   "jti-1",
+				SessionID: "sid-1",
+			},
+		},
+		{
+			name:    "missing subject and session id",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			// A logout token must contain a "sub" claim, a "sid" claim, or both.
+			payload: `{
+				"iss": "https://login.example.com",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			wantErr: true,
+		},
+		{
+			name:    "contains nonce",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			// A logout token must not contain a "nonce" claim.
+			payload: `{
+				"iss": "https://login.example.com",
+				"sub": "user-1",
+				"aud": "test-client-id",
+				"iat": 1781724897,
+				"exp": 1781725017,
+				"jti": "jti-1",
+				"sid": "sid-1",
+				"nonce": "n-0S6_WzA2Mj",
+				"events": {"http://schemas.openid.net/event/backchannel-logout": {}}
+			}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed payload",
+			signKey: newRSAKey(t),
+			config:  Config{ClientID: testLogoutClientID},
+			payload: `{"iss": "https://login.example.com", not valid json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			verificationKeys := tc.verificationKeys
+			if len(verificationKeys) == 0 {
+				verificationKeys = []*signingKey{tc.signKey}
+			}
+			var pubKeys []crypto.PublicKey
+			for _, k := range verificationKeys {
+				pubKeys = append(pubKeys, k.pub)
+			}
+
+			config := tc.config
+			if config.Now == nil {
+				config.Now = func() time.Time { return time.Unix(testLogoutIAT, 0) }
+			}
+
+			token := tc.signKey.sign(t, []byte(tc.payload))
+			keySet := &StaticKeySet{PublicKeys: pubKeys}
+			v := NewVerifier(testLogoutIssuer, keySet, &config)
+
+			got, err := v.VerifyLogout(t.Context(), token)
+			if err != nil {
+				if !tc.wantErr {
+					t.Fatalf("VerifyLogout() returned unexpected error: %v", err)
+				}
+				return
+			}
+			if tc.wantErr {
+				t.Fatalf("VerifyLogout() expected an error, got token: %#v", got)
+			}
+
+			// claims holds the raw payload, which isn't compared directly.
+			got.claims = nil
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("VerifyLogout() returned unexpected token\n got=%#v\nwant=%#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/oidc/verify.go
+++ b/oidc/verify.go
@@ -17,9 +17,10 @@ const (
 	issuerGoogleAccountsNoScheme = "accounts.google.com"
 )
 
-// TokenExpiredError indicates that Verify failed because the token was expired. This
-// error does NOT indicate that the token is not also invalid for other reasons. Other
-// checks might have failed if the expiration check had not failed.
+// TokenExpiredError indicates that Verify or VerifyLogout failed because the
+// token was expired. This error does NOT indicate that the token is not also
+// invalid for other reasons. Other checks might have failed if the expiration
+// check had not failed.
 type TokenExpiredError struct {
 	// Expiry is the time when the token expired.
 	Expiry time.Time
@@ -44,7 +45,7 @@ type KeySet interface {
 	VerifySignature(ctx context.Context, jwt string) (payload []byte, err error)
 }
 
-// IDTokenVerifier provides verification for ID Tokens.
+// IDTokenVerifier provides verification for ID Tokens and Logout Tokens.
 type IDTokenVerifier struct {
 	keySet KeySet
 	config *Config
@@ -203,48 +204,9 @@ func resolveDistributedClaim(ctx context.Context, verifier *IDTokenVerifier, src
 //
 //	token, err := verifier.Verify(ctx, rawIDToken)
 func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDToken, error) {
-	var supportedSigAlgs []jose.SignatureAlgorithm
-	for _, alg := range v.config.SupportedSigningAlgs {
-		supportedSigAlgs = append(supportedSigAlgs, jose.SignatureAlgorithm(alg))
-	}
-	if len(supportedSigAlgs) == 0 {
-		// If no algorithms were specified by both the config and discovery, default
-		// to the one mandatory algorithm "RS256".
-		supportedSigAlgs = []jose.SignatureAlgorithm{jose.RS256}
-	}
-	if v.config.InsecureSkipSignatureCheck {
-		// "none" is a required value to even parse a JWT with the "none" algorithm
-		// using go-jose.
-		supportedSigAlgs = append(supportedSigAlgs, "none")
-	}
-
-	// Parse and verify the signature first. This at least forces the user to have
-	// a valid, signed ID token before we do any other processing.
-	jws, err := jose.ParseSigned(rawIDToken, supportedSigAlgs)
+	payload, sig, err := v.verifyJWT(ctx, rawIDToken)
 	if err != nil {
-		return nil, fmt.Errorf("oidc: malformed jwt: %v", err)
-	}
-	switch len(jws.Signatures) {
-	case 0:
-		return nil, fmt.Errorf("oidc: id token not signed")
-	case 1:
-	default:
-		return nil, fmt.Errorf("oidc: multiple signatures on id token not supported")
-	}
-	sig := jws.Signatures[0]
-
-	var payload []byte
-	if v.config.InsecureSkipSignatureCheck {
-		// Yolo mode.
-		payload = jws.UnsafePayloadWithoutVerification()
-	} else {
-		// The JWT is attached here for the happy path to avoid the verifier from
-		// having to parse the JWT twice.
-		ctx = context.WithValue(ctx, parsedJWTKey, jws)
-		payload, err = v.keySet.VerifySignature(ctx, rawIDToken)
-		if err != nil {
-			return nil, fmt.Errorf("failed to verify signature: %v", err)
-		}
+		return nil, err
 	}
 	var token idToken
 	if err := json.Unmarshal(payload, &token); err != nil {
@@ -335,4 +297,51 @@ func (v *IDTokenVerifier) Verify(ctx context.Context, rawIDToken string) (*IDTok
 // OpenID Connect provider to contain the specified nonce.
 func Nonce(nonce string) oauth2.AuthCodeOption {
 	return oauth2.SetAuthURLParam("nonce", nonce)
+}
+
+func (v *IDTokenVerifier) verifyJWT(ctx context.Context, rawIDToken string) ([]byte, jose.Signature, error) {
+	var supportedSigAlgs []jose.SignatureAlgorithm
+	for _, alg := range v.config.SupportedSigningAlgs {
+		supportedSigAlgs = append(supportedSigAlgs, jose.SignatureAlgorithm(alg))
+	}
+	if len(supportedSigAlgs) == 0 {
+		// If no algorithms were specified by both the config and discovery, default
+		// to the one mandatory algorithm "RS256".
+		supportedSigAlgs = []jose.SignatureAlgorithm{jose.RS256}
+	}
+	if v.config.InsecureSkipSignatureCheck {
+		// "none" is a required value to even parse a JWT with the "none" algorithm
+		// using go-jose.
+		supportedSigAlgs = append(supportedSigAlgs, "none")
+	}
+
+	// Parse and verify the signature first. This at least forces the user to have
+	// a valid, signed ID token before we do any other processing.
+	jws, err := jose.ParseSigned(rawIDToken, supportedSigAlgs)
+	if err != nil {
+		return nil, jose.Signature{}, fmt.Errorf("oidc: malformed jwt: %v", err)
+	}
+	switch len(jws.Signatures) {
+	case 0:
+		return nil, jose.Signature{}, fmt.Errorf("oidc: id token not signed")
+	case 1:
+	default:
+		return nil, jose.Signature{}, fmt.Errorf("oidc: multiple signatures on id token not supported")
+	}
+	sig := jws.Signatures[0]
+
+	var payload []byte
+	if v.config.InsecureSkipSignatureCheck {
+		// Yolo mode.
+		payload = jws.UnsafePayloadWithoutVerification()
+	} else {
+		// The JWT is attached here for the happy path to avoid the verifier from
+		// having to parse the JWT twice.
+		ctx = context.WithValue(ctx, parsedJWTKey, jws)
+		payload, err = v.keySet.VerifySignature(ctx, rawIDToken)
+		if err != nil {
+			return nil, jose.Signature{}, fmt.Errorf("failed to verify signature: %v", err)
+		}
+	}
+	return payload, sig, nil
 }


### PR DESCRIPTION
This PR adds support for OpenID Connect Back-Channel Logout, where a relying party can receive a POST request from an identity provider indicating a user's sessions should be revoked.

Because so much of this logic replicates the ID Token claims checks, the API has been added to the existing IDTokenVerifier with a new VerifyLogout method to go with the existing Verify method.

A full example app that has been tested against Auth0's Back-Channel logout support is added to examples.

https://openid.net/specs/openid-connect-backchannel-1_0.html

Fixes #251
Fixes #211
Fixes #458