### PR TITLE
oidc: add constants for "email" and "profile" scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ oauth2Config := oauth2.Config{
     Endpoint: provider.Endpoint(),
 
     // "openid" is a required scope for OpenID Connect flows.
-    Scopes: []string{oidc.ScopeOpenID, "profile", "email"},
+    Scopes: []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail},
 }
 
 // Create an ID Token verifier.

--- a/example/idtoken/app.go
+++ b/example/idtoken/app.go
@@ -59,7 +59,7 @@ func main() {
 		ClientSecret: clientSecret,
 		Endpoint:     provider.Endpoint(),
 		RedirectURL:  "http://127.0.0.1:5556/auth/google/callback",
-		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+		Scopes:       []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail},
 	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/example/logout/app.go
+++ b/example/logout/app.go
@@ -104,7 +104,7 @@ func main() {
 		ClientSecret: clientSecret,
 		Endpoint:     provider.Endpoint(),
 		RedirectURL:  callbackURL,
-		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+		Scopes:       []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail},
 	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/example/userinfo/app.go
+++ b/example/userinfo/app.go
@@ -54,7 +54,7 @@ func main() {
 		ClientSecret: clientSecret,
 		Endpoint:     provider.Endpoint(),
 		RedirectURL:  "http://127.0.0.1:5556/auth/google/callback",
-		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+		Scopes:       []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail},
 	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/oidc/doc.go
+++ b/oidc/doc.go
@@ -17,7 +17,7 @@
 //	    // Discovery returns the OAuth2 endpoints.
 //	    Endpoint: provider.Endpoint(),
 //	    // "openid" is a required scope for OpenID Connect flows.
-//	    Scopes: []string{oidc.ScopeOpenID, "profile", "email"},
+//	    Scopes: []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail},
 //	}
 //
 //	idTokenVerifier := provider.Verifier(&oidc.Config{ClientID: clientID})

--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -23,6 +23,26 @@ const (
 	// ScopeOpenID is the mandatory scope for all OpenID Connect OAuth2 requests.
 	ScopeOpenID = "openid"
 
+	// ScopeProfile can be used to request information about the user's profile,
+	// such as "name", "picture", etc.
+	//
+	// The exact set of claims supported by identity providers differs widely,
+	// though "name" and "picture" are commonly returned.
+	//
+	// See: https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
+	ScopeProfile = "profile"
+
+	// ScopeEmail can be used to request the user's email address through the
+	// "email" and "email_verified" claims.
+	//
+	// What it means to verify an email isn't well defined. Clients can
+	// generally throw out emails when the "emvail_verified" claim is false, but
+	// should consult identity provider specific docs if attempting to ensure
+	// that the user controls the returned email address.
+	//
+	// See: https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
+	ScopeEmail = "email"
+
 	// ScopeOfflineAccess is an optional scope defined by OpenID Connect for requesting
 	// OAuth2 refresh tokens.
 	//


### PR DESCRIPTION
I've intentionally left out "address" and "phone" since they seem extremely dated compared to modern privacy practices. We shouldn't encourage their use.

Fixes https://github.com/coreos/go-oidc/issues/385
Fixes https://github.com/coreos/go-oidc/pull/387