### PR TITLE
example: use PKCE in the authorization code flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,26 @@ oauth2Config := oauth2.Config{
 idTokenVerifier := provider.Verifier(&oidc.Config{ClientID: clientID})
 ```
 
-OAuth2 redirects are unchanged.
+OAuth2 redirects are unchanged, except for PKCE ([RFC 7636][pkce]). The [OAuth 2.0
+Security Best Current Practice][oauth2-bcp] requires PKCE for public clients and
+recommends it for confidential ones, and some providers reject an authorization
+code exchange that omits it. `golang.org/x/oauth2` implements it: generate a
+verifier per authorization request, send its challenge on the redirect, and hold
+the verifier until the callback.
 
 ```go
 func handleRedirect(w http.ResponseWriter, r *http.Request) {
-    http.Redirect(w, r, oauth2Config.AuthCodeURL(state), http.StatusFound)
+    // A fresh verifier is required for each authorization request. Store it the
+    // same way the state is stored, so the callback can replay it.
+    codeVerifier := oauth2.GenerateVerifier()
+
+    http.Redirect(w, r, oauth2Config.AuthCodeURL(state,
+        oauth2.S256ChallengeOption(codeVerifier)), http.StatusFound)
 }
 ```
+
+[pkce]: https://datatracker.ietf.org/doc/html/rfc7636
+[oauth2-bcp]: https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.1
 
 Then, on the response, the ID Token verifier can be used to verify ID Tokens.
 
@@ -94,7 +107,9 @@ Then, on the response, the ID Token verifier can be used to verify ID Tokens.
 func handleOAuth2Callback(w http.ResponseWriter, r *http.Request) {
     // Verify state and errors.
 
-    oauth2Token, err := oauth2Config.Exchange(ctx, r.URL.Query().Get("code"))
+    // Replay the verifier held since the redirect.
+    oauth2Token, err := oauth2Config.Exchange(ctx, r.URL.Query().Get("code"),
+        oauth2.VerifierOption(codeVerifier))
     if err != nil {
         // handle error
     }
@@ -123,3 +138,12 @@ func handleOAuth2Callback(w http.ResponseWriter, r *http.Request) {
     }
 }
 ```
+
+## Examples
+
+The [example](example) directory holds runnable programs for the flows above,
+each performing the full authorization code exchange with PKCE:
+
+- [example/idtoken](example/idtoken) parses and verifies an ID Token.
+- [example/userinfo](example/userinfo) queries the UserInfo endpoint.
+- [example/logout](example/logout) verifies back-channel logout tokens.

--- a/example/idtoken/app.go
+++ b/example/idtoken/app.go
@@ -73,10 +73,12 @@ func main() {
 			http.Error(w, "Internal error", http.StatusInternalServerError)
 			return
 		}
+		codeVerifier := oauth2.GenerateVerifier()
 		setCallbackCookie(w, r, "state", state)
 		setCallbackCookie(w, r, "nonce", nonce)
+		setCallbackCookie(w, r, "code_verifier", codeVerifier)
 
-		http.Redirect(w, r, config.AuthCodeURL(state, oidc.Nonce(nonce)), http.StatusFound)
+		http.Redirect(w, r, config.AuthCodeURL(state, oidc.Nonce(nonce), oauth2.S256ChallengeOption(codeVerifier)), http.StatusFound)
 	})
 
 	http.HandleFunc("/auth/google/callback", func(w http.ResponseWriter, r *http.Request) {
@@ -90,7 +92,13 @@ func main() {
 			return
 		}
 
-		oauth2Token, err := config.Exchange(ctx, r.URL.Query().Get("code"))
+		codeVerifier, err := r.Cookie("code_verifier")
+		if err != nil {
+			http.Error(w, "code_verifier not found", http.StatusBadRequest)
+			return
+		}
+
+		oauth2Token, err := config.Exchange(ctx, r.URL.Query().Get("code"), oauth2.VerifierOption(codeVerifier.Value))
 		if err != nil {
 			http.Error(w, "Failed to exchange token: "+err.Error(), http.StatusInternalServerError)
 			return

--- a/example/logout/app.go
+++ b/example/logout/app.go
@@ -118,10 +118,12 @@ func main() {
 			http.Error(w, "Internal error", http.StatusInternalServerError)
 			return
 		}
+		codeVerifier := oauth2.GenerateVerifier()
 		setCallbackCookie(w, r, "state", state)
 		setCallbackCookie(w, r, "nonce", nonce)
+		setCallbackCookie(w, r, "code_verifier", codeVerifier)
 
-		http.Redirect(w, r, config.AuthCodeURL(state, oidc.Nonce(nonce)), http.StatusFound)
+		http.Redirect(w, r, config.AuthCodeURL(state, oidc.Nonce(nonce), oauth2.S256ChallengeOption(codeVerifier)), http.StatusFound)
 	})
 
 	http.HandleFunc("POST /logout", func(w http.ResponseWriter, r *http.Request) {
@@ -153,7 +155,13 @@ func main() {
 			return
 		}
 
-		oauth2Token, err := config.Exchange(ctx, r.URL.Query().Get("code"))
+		codeVerifier, err := r.Cookie("code_verifier")
+		if err != nil {
+			http.Error(w, "code_verifier not found", http.StatusBadRequest)
+			return
+		}
+
+		oauth2Token, err := config.Exchange(ctx, r.URL.Query().Get("code"), oauth2.VerifierOption(codeVerifier.Value))
 		if err != nil {
 			http.Error(w, "Failed to exchange token: "+err.Error(), http.StatusInternalServerError)
 			return

--- a/example/userinfo/app.go
+++ b/example/userinfo/app.go
@@ -63,9 +63,11 @@ func main() {
 			http.Error(w, "Internal error", http.StatusInternalServerError)
 			return
 		}
+		codeVerifier := oauth2.GenerateVerifier()
 		setCallbackCookie(w, r, "state", state)
+		setCallbackCookie(w, r, "code_verifier", codeVerifier)
 
-		http.Redirect(w, r, config.AuthCodeURL(state), http.StatusFound)
+		http.Redirect(w, r, config.AuthCodeURL(state, oauth2.S256ChallengeOption(codeVerifier)), http.StatusFound)
 	})
 
 	http.HandleFunc("/auth/google/callback", func(w http.ResponseWriter, r *http.Request) {
@@ -79,7 +81,13 @@ func main() {
 			return
 		}
 
-		oauth2Token, err := config.Exchange(ctx, r.URL.Query().Get("code"))
+		codeVerifier, err := r.Cookie("code_verifier")
+		if err != nil {
+			http.Error(w, "code_verifier not found", http.StatusBadRequest)
+			return
+		}
+
+		oauth2Token, err := config.Exchange(ctx, r.URL.Query().Get("code"), oauth2.VerifierOption(codeVerifier.Value))
 		if err != nil {
 			http.Error(w, "Failed to exchange token: "+err.Error(), http.StatusInternalServerError)
 			return

--- a/oidc/doc.go
+++ b/oidc/doc.go
@@ -22,10 +22,18 @@
 //
 //	idTokenVerifier := provider.Verifier(&oidc.Config{ClientID: clientID})
 //
-// OAuth 2.0 redirects then opt into the OpenID Connect flow with [ScopeOpenID]:
+// OAuth 2.0 redirects then opt into the OpenID Connect flow with [ScopeOpenID].
+// Redirects also carry a PKCE challenge (RFC 7636), which RFC 9700 requires for
+// public clients and recommends for confidential ones. Generate a fresh verifier
+// per authorization request and store it the way the state is stored, so the
+// callback can replay it:
 //
 //	func handleRedirect(w http.ResponseWriter, r *http.Request) {
-//		http.Redirect(w, r, oauth2Config.AuthCodeURL(state), http.StatusFound)
+//		codeVerifier := oauth2.GenerateVerifier()
+//		// Store codeVerifier for the callback, e.g. in a secure cookie.
+//
+//		http.Redirect(w, r, oauth2Config.AuthCodeURL(state,
+//			oauth2.S256ChallengeOption(codeVerifier)), http.StatusFound)
 //	}
 //
 // When handling an OAuth 2.0 response, an [IDTokenVerifier] can be used to
@@ -35,8 +43,10 @@
 //	func handleOAuth2Callback(w http.ResponseWriter, r *http.Request) {
 //		// Verify state and other OAuth 2.0 responses.
 //
-//		// Perform standard token exchange.
-//		oauth2Token, err := oauth2Config.Exchange(r.Context(), r.URL.Query().Get("code"))
+//		// Perform standard token exchange, replaying the PKCE verifier held
+//		// since the redirect.
+//		oauth2Token, err := oauth2Config.Exchange(r.Context(), r.URL.Query().Get("code"),
+//			oauth2.VerifierOption(codeVerifier))
 //		if err != nil {
 //			// ...
 //		}


### PR DESCRIPTION
## Problem

The three programs under `example/` run the authorization code flow without PKCE, and neither the README nor the package documentation mentions it anywhere. Someone starting from an example therefore gets a flow with no protection against authorization code injection — which [RFC 9700 §2.1.1](https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.1) requires of public clients and recommends for confidential ones — and some providers reject an exchange that omits it.

`golang.org/x/oauth2` already provides `GenerateVerifier`, `S256ChallengeOption`, and `VerifierOption`, and this module depends on v0.36.0, so nothing new is pulled in.

Closes #496

## Changes

Two commits:

1. **`example:`** — all three examples generate a verifier per authorization request, send its S256 challenge on the redirect, and replay the verifier on the exchange. The verifier rides on the existing `setCallbackCookie` helper, exactly the way `state` and `nonce` already cross the redirect, so this mirrors what each example does rather than introducing a second mechanism. (Named `codeVerifier` because `verifier` is already taken by the ID Token verifier in two of the three.)

2. **`README, oidc:`** — document the verifier/challenge pair in the README snippets and in `oidc/doc.go`, and add a README section linking the three programs. The README previously never pointed at `example/` at all.

## Testing

Ran each example against a live discovery document and captured the redirect:

- `example/idtoken` and `example/userinfo` against `accounts.google.com`
- `example/logout` against `demo.duendesoftware.com`, since Google publishes no `end_session_endpoint`

All three emit `code_challenge` and `code_challenge_method=S256` on the authorization URL and set an `HttpOnly` `code_verifier` cookie, with `state`/`nonce` unaffected. I checked the pair is cryptographically consistent rather than merely present — from the `idtoken` run:

```
code_verifier               = _QJdctEKTn4qLxe7k70EEn8b5v4akgLusDWJDRJM0WY
code_challenge              = v6QQksnXv3_L_u-v4Onc_8dZheRhZRdFi8KfJVR-LzY
BASE64URL(SHA256(verifier)) = v6QQksnXv3_L_u-v4Onc_8dZheRhZRdFi8KfJVR-LzY   ← match
```

I also drove the same call pattern through a stub token endpoint to confirm the token request carries a `code_verifier` equal to the original, that the plaintext verifier never leaks onto the front channel, and that dropping the options sends no PKCE parameters at all. That was scratch verification and is not in this PR, since `example/` carries no tests.

`gofmt -l .` is clean; `go build ./...`, `go vet ./...`, and `go test ./...` pass.

## Open to feedback

- **Scope reading.** I read "add PKCE to examples" as "make the examples do it" rather than "add a separate PKCE example", since a standalone one would imply PKCE is an opt-in variant. Happy to split it out instead if you meant the latter.
- **Touching the README/godoc snippets.** I updated those so they don't contradict the examples. If you'd rather the prose stayed as it was and only gained the link, that's a smaller diff and I'll trim it.
- **The linked thread.** I could not read the Reddit post (Reddit blocks automated fetching), so this is written from the repo state — no PKCE in code, docs, or examples — rather than from the specific confusion described there. If the thread was pointing at something narrower, tell me and I'll retarget.

### 🤖 AI assistance

Written with Claude Code. I reviewed every line and ran the verification above myself. One correction worth surfacing: the draft first claimed RFC 9700 requires PKCE for *every* authorization code exchange. Checking the RFC showed that is only true for public clients — for confidential ones it is RECOMMENDED, and confidential OpenID Connect clients MAY use `nonce` instead — so the wording now reflects that distinction. Since these examples are confidential clients that already send a nonce, the accurate framing is "recommended and widely required in practice", not "mandated".