### PR TITLE
oidc: ignore JWKs with unsupported key types rather than failing

### DIFF
--- a/oidc/jwks.go
+++ b/oidc/jwks.go
@@ -278,6 +278,20 @@ func (j *jwkJSON) UnmarshalJSON(data []byte) error {
 		}
 		var jwk jose.JSONWebKey
 		if err := json.Unmarshal(key, &jwk); err != nil {
+			// Ignore keys with types that go-jose doesn't support, such as
+			// OKP keys with Ed448 or X448 curves. Some providers include
+			// them in their key sets without an "alg" value, so the check
+			// above doesn't catch them.
+			//
+			// https://datatracker.ietf.org/doc/html/rfc7517#section-5
+			//
+			//     Implementations SHOULD ignore JWKs within a JWK Set that use
+			//     "kty" (key type) values that are not understood by them, that
+			//     are missing required members, or for which values are out of
+			//     the supported ranges.
+			if errors.Is(err, jose.ErrUnsupportedKeyType) {
+				continue
+			}
 			return err
 		}
 		j.Keys = append(j.Keys, jwk)

--- a/oidc/jwks_test.go
+++ b/oidc/jwks_test.go
@@ -426,3 +426,72 @@ func TestJWKParseWithIgnoredKeys(t *testing.T) {
 		t.Errorf("expected payload %q got %q", "payload", string(got))
 	}
 }
+
+func TestJWKParseWithUnsupportedKeys(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubKey := jose.JSONWebKey{
+		Key:       priv.Public(),
+		Use:       "sig",
+		Algorithm: string(jose.ES256),
+		KeyID:     "key1",
+	}
+	pubRaw, err := json.Marshal(pubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privKey := jose.JSONWebKey{
+		Key:       priv,
+		Use:       "sig",
+		Algorithm: string(jose.ES256),
+		KeyID:     "key1",
+	}
+
+	hf := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{
+			"keys": [
+				`+string(pubRaw)+`,
+				{
+					"kty": "OKP",
+					"crv": "Ed448",
+					"kid": "oidc-ed448-1",
+					"use": "sig",
+					"x": "gH1eRK-6hW6ZoAy2k11U4L5uaIaMaZTMCf1cAbsxsYLvTqV2-TQG1PNyLOrhZkMyzUJulMc1wAfH"
+				},
+				{
+					"kty": "OKP",
+					"crv": "X448",
+					"kid": "oidc-x448-1",
+					"use": "enc",
+					"x": "5Tegc13rI3bLqrCiUo-Cg1Ijjaj0l1aZrkVfUFbp-B5CGSj5z3wdAr3B0K7pPYDm9qbtjmMKOf0"
+				}
+			]
+		}`)
+	}
+
+	ks := NewRemoteKeySet(t.Context(), httptest.NewServer(http.HandlerFunc(hf)).URL)
+
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES256, Key: &privKey}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jws, err := signer.Sign([]byte("payload"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	serialized, err := jws.CompactSerialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ks.VerifySignature(t.Context(), serialized)
+	if err != nil {
+		t.Fatalf("failed to verify signature: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Errorf("expected payload %q got %q", "payload", string(got))
+	}
+}


### PR DESCRIPTION
Fixes #498

Skip keys whose unmarshal fails with `jose.ErrUnsupportedKeyType` instead of failing the whole set, same as the existing "alg" skip.